### PR TITLE
Update QCElemental 0.17.0 -> 0.19.0

### DIFF
--- a/qcelemental/default.nix
+++ b/qcelemental/default.nix
@@ -12,7 +12,7 @@
 }:
 buildPythonPackage rec {
   pname = "qcelemental";
-  version = "0.17.0";
+  version = "0.19.0";
 
   checkInputs = [
     pytestrunner
@@ -30,7 +30,7 @@ buildPythonPackage rec {
 
   src = fetchPypi  {
     inherit pname version;
-    sha256 = "0xsxmj1l6l72ga06a1gy2kf7lqdgnx8hcgqw0ikvzgs0xj2w4421";
+    sha256 = "1ljxwhiz1689qijjqzmzydn8q963xx7zxizjnjq0vqg5py9pkyc5";
   };
 
   doCheck = true;


### PR DESCRIPTION
The issues from #7 have been resolved upstream by replacing deprecated Numpy functions, see [here](https://github.com/MolSSI/QCElemental/pull/246). Simply raising the QCElemental version solves the problem with the Numpy updates from Nixpkgs master, both for QCElemental and Psi4.

Closes #7 