### PR TITLE
GPAW 21.1.0

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -138,6 +138,8 @@ let
 
       mt-dgemm = callPackage ./mt-dgemm { };
 
+      multiwfn = callPackage ./multiwfn { };
+
       orca = callPackage ./orca { };
 
       osu-benchmark = callPackage ./osu-benchmark {
@@ -180,10 +182,10 @@ let
 
       stream-benchmark = callPackage ./stream { };
 
+      turbomole = callPackage ./turbomole {};
+
       vmd = callPackage ./vmd {};
 
-      multiwfn = callPackage ./multiwfn {};
-      turbomole = callPackage ./turbomole {};
 
 
 

--- a/default.nix
+++ b/default.nix
@@ -203,6 +203,8 @@ let
 
       libint2 = callPackage ./libint { inherit optAVX; };
 
+      libvdwxc = callPackage ./libvdwxc { };
+
       # libint configured for bagel
       # See https://github.com/evaleev/libint/wiki#bagel
       libint-bagel = callPackage ./libint { cfg = [

--- a/default.nix
+++ b/default.nix
@@ -63,6 +63,19 @@ let
         buildInputs = [ self_.gfortran ];
       });
 
+      fftw-mpi = self.fftw.overrideAttrs (oldAttrs: {
+        buildInputs = oldAttrs.buildInputs ++ [
+          self.mpi
+        ];
+
+        configureFlags = with lib.lists; oldAttrs.configureFlags ++ [
+          "--enable-mpi"
+          "MPICC=${self_.mpi}/bin/mpicc"
+          "MPIFC=${self_.mpi}/bin/mpif90"
+          "MPIF90=${self_.mpi}/bin/mpif90"
+        ];
+      });
+
       # For molcas and chemps2
       hdf5-full = self_.hdf5.override {
         cpp = true;
@@ -113,6 +126,8 @@ let
       ergoscf = callPackage ./ergoscf { };
 
       gaussview = callPackage ./gaussview { };
+
+      gpaw = super.python3.pkgs.toPythonApplication self.python3.pkgs.gpaw;
 
       nwchem = callPackage ./nwchem { blas=self.blas-i8; lapack=self.lapack-i8; };
 

--- a/gpaw/default.nix
+++ b/gpaw/default.nix
@@ -1,0 +1,126 @@
+{ fetchFromGitLab, buildPythonPackage, lib, writeTextFile, makeWrapper, fetchurl, blas, lapack,
+  scalapack, mpi, fftw, libxc, libvdwxc, which, ase, numpy, scipy
+}:
+assert
+  lib.asserts.assertMsg
+  (!blas.isILP64)
+  "A 32 bit integer implementation of BLAS is required.";
+
+assert
+  lib.asserts.assertMsg
+  (!lapack.isILP64)
+  "A 32 bit integer implementation of LAPACK is required.";
+
+let
+  gpawConfig = writeTextFile {
+    name = "siteconfig.py";
+    text = ''
+      # Compiler
+      compiler = 'gcc'
+      mpicompiler = '${mpi}/bin/mpicc'
+      mpilinker = '${mpi}/bin/mpicc'
+
+      # BLAS
+      libraries += ['blas']
+      library_dirs += ['${blas}/lib']
+
+      # FFTW
+      fftw = True
+      if fftw:
+        libraries += ['fftw3']
+
+      scalapack = True
+      if scalapack:
+        libraries += ['scalapack']
+
+      # LibXC
+      libxc = True
+      if libxc:
+        xc = '${libxc}/'
+        include_dirs += [xc + 'include']
+        library_dirs += [xc + 'lib/']
+        extra_link_args += ['-Wl,-rpath={xc}/lib'.format(xc=xc)]
+        if 'xc' not in libraries:
+          libraries.append('xc')
+
+      # LibVDWXC
+      libvdwxc = True
+      if libvdwxc:
+        vdwxc = '${libvdwxc}/'
+        extra_link_args += ['-Wl,-rpath=%s/lib' % vdwxc]
+        library_dirs += ['%s/lib' % vdwxc]
+        include_dirs += ['%s/include' % vdwxc]
+        libraries += ['vdwxc']
+    '';
+  };
+
+  setupVersion = "0.9.20000";
+  pawDataSets = fetchurl {
+    url = "https://wiki.fysik.dtu.dk/gpaw-files/gpaw-setups-${setupVersion}.tar.gz";
+    sha256 = "07yldxnn38gky39fxyv3rfzag9p4lb0xfpzn15wy2h9aw4mnhwbc";
+  };
+in
+  buildPythonPackage rec {
+    pname = "gpaw";
+    version = "21.1.0";
+
+    nativeBuildInputs = [
+      which
+      makeWrapper
+    ];
+
+    buildInputs = [
+      blas
+      scalapack
+      fftw
+      libxc
+      libvdwxc
+    ];
+
+    propagatedBuildInputs = [
+      ase
+      scipy
+      numpy
+      mpi
+    ];
+
+    src = fetchFromGitLab  {
+      owner = "gpaw";
+      repo = pname;
+      rev = version;
+      sha256 = "0xws39yq5d1ih4zj31bdd0h64afs6x9j30yrrycxf3pnc5h9wbr0";
+    };
+
+    postInstall = ''
+      currDir=$(pwd)
+      mkdir -p $out/share/gpaw && cd $out/share/gpaw
+      cp ${pawDataSets} gpaw-setups.tar.gz
+      tar -xvf $out/share/gpaw/gpaw-setups.tar.gz
+      rm gpaw-setups.tar.gz
+      cd $currDir
+    '';
+
+    doCheck = false;
+    preCheck = ''
+      # export PATH=$PATH:${mpi}/bin
+      export GPAW_SETUP_PATH=$out/share/gpaw/gpaw-setups-${setupVersion}
+    '';
+
+    postPatch = ''
+      cp ${gpawConfig} siteconfig.py
+    '';
+
+    postFixup = ''
+      for exe in $out/bin/*; do
+        wrapProgram $exe \
+          --set "GPAW_SETUP_PATH" "$out/share/gpaw/gpaw-setups-${setupVersion}"
+      done
+    '';
+
+    meta = with lib; {
+      description = "DFT and beyond within the projector-augmented wave method";
+      license = licenses.gpl3Only;
+      homepage = "https://wiki.fysik.dtu.dk/gpaw/index.html";
+      platforms = platforms.unix;
+    };
+  }

--- a/gpaw/default.nix
+++ b/gpaw/default.nix
@@ -1,5 +1,5 @@
 { fetchFromGitLab, buildPythonPackage, lib, writeTextFile, makeWrapper, fetchurl, blas, lapack,
-  scalapack, mpi, fftw, libxc, libvdwxc, which, ase, numpy, scipy
+  scalapack, mpi, fftw-mpi, libxc, libvdwxc, which, ase, numpy, scipy
 }:
 assert
   lib.asserts.assertMsg
@@ -72,7 +72,7 @@ in
     buildInputs = [
       blas
       scalapack
-      fftw
+      fftw-mpi
       libxc
       libvdwxc
     ];

--- a/libvdwxc/default.nix
+++ b/libvdwxc/default.nix
@@ -1,0 +1,53 @@
+{ stdenv, lib, fetchFromGitLab, gfortran, autoreconfHook, fftw-mpi, mpi
+}:
+stdenv.mkDerivation rec {
+  pname = "libvdwxc";
+  # Stable version has non-working MPI detection.
+  version = "24.02.2020";
+
+  nativeBuildInputs = [
+    autoreconfHook
+    gfortran
+  ];
+
+  buildInputs = [
+    fftw-mpi
+  ];
+
+  propagatedBuildInputs = [
+    mpi
+  ];
+
+  preConfigure = ''
+    mkdir build && cd build
+
+    export PATH=$PATH:${mpi}/bin
+    configureFlagsArray+=(
+      --with-mpi=${mpi}
+      CC=mpicc
+      FC=mpif90
+      MPICC=mpicc
+      MPIFC=mpif90
+    )
+  '';
+
+  configureScript = "../configure";
+
+  src = fetchFromGitLab  {
+    owner = "libvdwxc";
+    repo = pname;
+    rev = "92f4910c6ac88e111db2fb3a518089d0510c53b0";
+    sha256= "1c7pjrvifncbdyngs2bv185imxbcbq64nka8gshhp8n2ns6fids6";
+  };
+
+  hardeningDisable = [
+    "format"
+  ];
+
+  meta = with lib; {
+    description = "Portable C library of density functionals with van der Waals interactions for density functional theory";
+    license = with licenses; [ lgpl3Plus bsd3 ];
+    homepage = "https://libvdwxc.org/";
+    platforms = platforms.unix;
+  };
+}

--- a/nixpkgs-opt.nix
+++ b/nixpkgs-opt.nix
@@ -16,6 +16,21 @@ self: super:
     buildInputs = oldAttrs.buildInputs ++ [ self.gfortran ];
   });
 
+  fftw-mpi = self.fftw.overrideAttrs ( oldAttrs: {
+    buildInputs = oldAttrs.buildInputs ++ [
+      self.mpi
+    ];
+
+    configureFlags = with super.lib.lists; oldAttrs.configureFlags ++ [
+      "--enable-mpi"
+      "MPICC=${self.mpi}/bin/mpicc"
+      "MPIFC=${self.mpi}/bin/mpif90"
+      "MPIF90=${self.mpi}/bin/mpif90"
+    ];
+  });
+
+
+
   fftwSinglePrec = self.fftw.override { precision = "single"; };
 
   libxsmm = super.libxsmm.overrideAttrs ( x: {

--- a/pythonPackages.nix
+++ b/pythonPackages.nix
@@ -21,6 +21,8 @@ let
 
     qcengine = callPackage ./qcengine { };
 
+    gpaw = callPackage ./gpaw { };
+
     gau2grid = callPackage ./gau2grid { };
     gau2grid-1_3_1 = callPackage ./gau2grid { version = "1.3.1"; sha256 = "0zkfil7cxjip79wqvhljk1ifjq0cwxzx6wlxgp63b6wbagma0i12"; };
     gau2grid-2_0_4 = callPackage ./gau2grid { version = "2.0.4"; sha256 = "0qypq8iax0n6yfi4223zya468v24b60nr0x43ypmsafj0104zqa6"; };


### PR DESCRIPTION
Adds GPAW as python library and application. Unfortunately I have no idea how to get the checkPhase working. It requires working MPI and fails with some missing rsh. Works otherwise.

Some probably important change: i habe enabled the AVX tunings and MPI for FFTW in the overlay. GPAW requires the MPI bindings of FFTW.