### PR TITLE
Multiwfn 3.7

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -182,6 +182,8 @@ let
 
       vmd = callPackage ./vmd {};
 
+      multiwfn = callPackage ./multiwfn {};
+
 
 
       ### Python packages
@@ -306,4 +308,3 @@ let
 
 in
   overlay cfg.prefix { }
-

--- a/multiwfn/default.nix
+++ b/multiwfn/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, lib, makeWrapper, requireFile, autoPatchelfHook, unzip,
+  writeScriptBin, fetchurl, glibc, xorg, libGL, motif
+}:
+stdenv.mkDerivation rec {
+    pname = "multiwfn";
+    version = "3.7";
+
+    nativeBuildInputs = [
+      makeWrapper
+      autoPatchelfHook
+      unzip
+    ];
+
+    buildInputs = [
+      xorg.libX11
+      libGL
+      motif
+    ];
+
+    # Only builds with Intel tooling. ifort is not available in Nix, therefore the binary package.
+    src = fetchurl {
+      url = "http://sobereva.com/multiwfn/misc/Multiwfn_${version}_bin_Linux.zip";
+      sha256 = "1xv8kicc34c5fx1mddmm9a94j5nm7nr6yrsvfm5v59a0wgk76rbs";
+    };
+
+    dontConfigure = true;
+    dontBuild = true;
+
+    installPhase = ''
+      mkdir -p $out/bin $out/share/multiwfn
+
+      # Copy binary to $out
+      chmod +x Multiwfn
+      cp Multiwfn $out/bin/.
+
+      # Copy examples and settings
+      cp -r examples settings.ini $out/share/multiwfn/.
+
+      # Symlink the settings.
+      ln -s $out/share/multiwfn/settings.ini $out/bin/.
+    '';
+
+    meta = with lib; {
+      description = "Multifunctional wave function analyser.";
+      license = licenses.bsd3;
+      homepage = "http://sobereva.com/multiwfn/index.html";
+      platforms = [ "x86_64-linux" ];
+    };
+  }


### PR DESCRIPTION
Adds Multiwfn to the package set. It's a Fortran program but absolutely only builds with Intel's ifort. The author is aware and not willing to fix it. As long as the Intel compilers don't make it into nixpkgs the binary is the only option.