### PR TITLE
libvori: init at 201229, libint: fix dead URLs, cp2k: add libvori

### DIFF
--- a/cp2k/default.nix
+++ b/cp2k/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, python3, gfortran, blas, lapack
-, fftw, libint2, libxc, mpi, gsl, scalapack, openssh, makeWrapper
+, fftw, libint2, libvori, libxc, mpi, gsl, scalapack, openssh, makeWrapper
 , libxsmm, spglib, which
 , optAVX ? false
 } :
@@ -24,7 +24,20 @@ in stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ python3 which openssh makeWrapper ];
-  buildInputs = [ gfortran fftw gsl libint2 libxc libxsmm  spglib blas lapack mpi scalapack ];
+  buildInputs = [
+    gfortran
+    fftw
+    gsl
+    libint2
+    libvori
+    libxc
+    libxsmm
+    spglib
+    blas
+    lapack
+    mpi
+    scalapack
+  ];
 
   makeFlags = [
     "ARCH=${arch}"
@@ -49,7 +62,7 @@ in stdenv.mkDerivation rec {
     AR         = ar -r
     DFLAGS     = -D__FFTW3 -D__LIBXC -D__LIBINT -D__parallel -D__SCALAPACK \
                  -D__MPI_VERSION=3 -D__F2008 -D__LIBXSMM -D__SPGLIB \
-                 -D__MAX_CONTR=4
+                 -D__MAX_CONTR=4 -D__LIBVORI
 
     CFLAGS    = -fopenmp
     FCFLAGS    = \$(DFLAGS) -O2 -ffree-form -ffree-line-length-none \
@@ -61,7 +74,7 @@ in stdenv.mkDerivation rec {
                  -I${libint2}/include
     LIBS       = -lfftw3 -lfftw3_threads -lscalapack -lblas -llapack \
                  -lxcf03 -lxc -lxsmmf -lxsmm -lsymspg \
-                 -lint2 -lstdc++ \
+                 -lint2 -lstdc++ -lvori \
                  -fopenmp
     LDFLAGS    = \$(FCFLAGS) \$(LIBS)
     EOF
@@ -100,4 +113,3 @@ in stdenv.mkDerivation rec {
     platforms = [ "x86_64-linux" ];
   };
 }
-

--- a/default.nix
+++ b/default.nix
@@ -218,6 +218,8 @@ let
       ] ++ lib.optional optAVX "--enable-fma"
       ;};
 
+      libvori = callPackage ./libvori { };
+
       # legacy version
       libxc4 = callPackage ./libxc { };
 

--- a/libint/default.nix
+++ b/libint/default.nix
@@ -23,11 +23,9 @@ stdenv.mkDerivation rec {
     sha256 = "0pbc2j928jyffhdp4x5bkw68mqmx610qqhnb223vdzr0n2yj5y19";
   };
 
-  patches = [ (fetchpatch {
-    name = "fortran_bindings";
-    url = "https://sources.debian.org/data/main/libi/libint2/2.6.0-4/debian/patches/fortran_bindings.patch";
-    sha256 = "0x71xldmk0agdk61x7k39r743nvq3irxy6s3djyg59r8yby9a6vc";
-  })];
+  patches = [
+    ./patches/fortran_bindings_debian.patch
+  ];
 
   postPatch = ''
     find -name Makefile -exec sed -i 's:/bin/rm:rm:' \{} \;
@@ -66,4 +64,3 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
   };
 }
-

--- a/libint/patches/fortran_bindings_debian.patch
+++ b/libint/patches/fortran_bindings_debian.patch
@@ -1,0 +1,33 @@
+--- ./export/fortran/Makefile.orig	2019-08-25 22:12:32.365443414 +0200
++++ ./export/fortran/Makefile	2019-08-25 22:12:39.401461731 +0200
+@@ -1,12 +1,14 @@
+-TOPDIR = ..
+-SRCDIR = ..
++TOPDIR = ../..
++SRCDIR = ../..
+
+--include ../MakeSuffixRules
+--include ../MakeVars
+--include ../MakeVars.features
++-include ../../lib/MakeSuffixRules
++-include ../../src/bin/MakeVars
++-include ../../src/lib/libint/MakeVars.features
+
+-FCFLAGS := -I../include -I../include/libint2 -D__COMPILING_LIBINT2=1 $(FCFLAGS)
+-COMPUTE_LIB = -L../lib -lint2
++FCFLAGS := -I../../include -I../../include/libint2 -D__COMPILING_LIBINT2=1 $(FCFLAGS)
++COMPUTE_LIB = -L../../lib -lint2
++
++CXXCPP = cc -E -I../../include/libint2
+
+ .PHONY: clean distclean default make_test check_test
+
+@@ -28,7 +30,7 @@
+
+ fortran_example.o: libint_f.o
+
+-fortran_incldefs.h: $(TOPDIR)/include/libint2_types.h
++fortran_incldefs.h: $(TOPDIR)/include/libint2/libint2_types.h
+ 	grep '^#' $< | grep -v '#include' > $@
+
+ fortran_example: fortran_example.o libint_f.o

--- a/libvori/default.nix
+++ b/libvori/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, lib, cmake }:
+stdenv.mkDerivation rec {
+  pname = "libvori";
+  version = "201229";
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  # Original server is misconfigured and messes up the file compression.
+  src = builtins.fetchTarball {
+    url = "https://www.cp2k.org/static/downloads/${pname}-${version}.tar.gz";
+    sha256 = "0j5f4v380qxaf55zq8ksk9d5xzhiklcwp5fanx9apxs3qhzdlk9z";
+  };
+
+  meta = with lib; {
+    description = "Library for Voronoi intergration of electron densities";
+    license = with licenses; [ lgpl3Only ];
+    homepage = "https://brehm-research.de/libvori.php";
+    platforms = platforms.unix;
+  };
+}


### PR DESCRIPTION
This adds libvori for voronoi integration of electron densities and BQB cube compression to the overlay and specifically to CP2K. LibVori allows for efficient AIMD trajectories to obtain vibrational spectra from Cube/BQB trajectories.

The URL to the Debian-LibInt patch already died some time ago. As I still had it in the store, i just added this patch to the repo itself now. Otherwise LibInt wont compile, unless you still have the patch-sources available.