### PR TITLE
travis: init at 03.06.2020

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -193,6 +193,8 @@ let
 
       stream-benchmark = callPackage ./stream { };
 
+      travis-analyzer = callPackage ./travis-analyzer { };
+
       turbomole = callPackage ./turbomole {};
 
       vmd = callPackage ./vmd {};

--- a/travis-analyzer/default.nix
+++ b/travis-analyzer/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, lib }:
+stdenv.mkDerivation rec {
+    pname = "travis-analyzer";
+    version = "03Jun2020";
+
+    src = fetchTarball  {
+      url = "http://www.travis-analyzer.de/files/travis-src-200504-hf2.tar.gz";
+      sha256= "1244w0sqb976c038hfkxvj4iym9nfbzhnisscrzx6vdr7q1g8pxh";
+    };
+
+    dontConfigure = true;
+    enableParallelBuilding = true;
+    installPhase = ''
+      mkdir -p $out/bin
+      cp exe/travis $out/bin/.
+    '';
+
+    meta = with lib; {
+      description = "Molecular dynamics trajectory analyzer and visualizer";
+      license = licenses.lgpl3Only;
+      homepage = "http://www.travis-analyzer.de/";
+      platforms = platforms.linux;
+    };
+  }


### PR DESCRIPTION
Adds travis for many MD analyses methods. Especially useful with CP2K and LibVori to calculate vibrational spectra from AIMD.