### PR TITLE
i-PI: init at 2.3.0

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -135,6 +135,8 @@ let
 
       gpaw = super.python3.pkgs.toPythonApplication self.python3.pkgs.gpaw;
 
+      i-pi = super.python3.pkgs.toPythonApplication self.python3.pkgs.i-pi;
+
       nwchem = callPackage ./nwchem {
         blas=self.blas-i8;
         lapack=self.lapack-i8;

--- a/i-pi/default.nix
+++ b/i-pi/default.nix
@@ -1,0 +1,38 @@
+{ buildPythonPackage, lib, fetchFromGitHub, gfortran, makeWrapper, numpy, pytest, mock, pytest-mock }:
+
+buildPythonPackage rec {
+  name = "i-PI";
+  version = "2.3.0";
+
+  src = fetchFromGitHub {
+    owner = "i-pi";
+    repo = "i-pi";
+    rev = "v${version}";
+    sha256 = "18aavj2x5vxl2i8ssk757rnbi6hygqpf4nsppxjjpmwjb7lw1ad3";
+  };
+
+  nativeBuildInputs = [
+    gfortran
+    makeWrapper
+  ];
+
+  propagatedBuildInputs = [ numpy ];
+
+  checkInputs = [
+    pytest
+    mock
+    pytest-mock
+  ];
+
+  postFixup = ''
+    wrapProgram $out/bin/i-pi \
+      --set IPI_ROOT $out
+  '';
+
+  meta = with lib; {
+    description = "A universal force engine";
+    license = licenses.gpl3Only;
+    homepage = "http://ipi-code.org/";
+    platforms = platforms.linux;
+  };
+}

--- a/pythonPackages.nix
+++ b/pythonPackages.nix
@@ -13,6 +13,8 @@ let
     pychemps2 = callPackage ./chemps2/PyChemMPS2.nix { };
 
   } // lib.optionalAttrs super.isPy3k {
+    i-pi = callPackage ./i-pi { };
+
     pyqdng = callPackage ./pyQDng { };
 
     pyscf = callPackage ./pyscf { };


### PR DESCRIPTION
Addition of the i-PI engine. This provides a decentralised python server, that allows for path integral molecular dynamics distributed over nodes of a cluster or local calculations. Required by our own software.