### PR TITLE
wfoverlap: init at 24.08.2020

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -208,11 +208,14 @@ let
 
       vmd = callPackage ./vmd {};
 
+      wfoverlap = callPackage ./wfoverlap {};
+        
       xtb = callPackage ./xtb {
         turbomole = null;
         cefine = null;
         orca = self.orca;
       };
+
 
 
 

--- a/wfoverlap/Makefile.patch
+++ b/wfoverlap/Makefile.patch
@@ -1,0 +1,37 @@
+diff --git a/Makefile b/Makefile
+index 27b0e9a..eb95272 100644
+--- a/Makefile
++++ b/Makefile
+
+ ############## Main objects and libraries #######
+
+@@ -62,12 +62,12 @@ DUMMYOBS=read_dalton_dummy.o read_molcas_dummy.o
+
+ ############## Dalton and SEWARD ################
+ # no Dalton and SEWARD support
+-#LIBS = $(LALIB)
+-#OPTOBS = $(DUMMYOBS)
++LIBS = $(LALIB)
++OPTOBS = $(DUMMYOBS)
+
+ # activate direct reading of Dalton and Seward files
+ #LIBS = $(COLUMBUS)/libmolcas_col.a $(COLUMBUS)/colib.a $(COLUMBUS)/blaswrapper.a  $(LALIB)
+-OPTOBS = read_dalton.o read_molcas.o
++#OPTOBS = read_dalton.o read_molcas.o
+
+ ############## Compilation routines #############
+
+@@ -80,13 +80,10 @@ OPTOBS = read_dalton.o read_molcas.o
+
+ wfoverlap.x : main.f90 $(MAINOBS) $(OPTOBS) iomod.o
+ 	$(FC) $(FCFLAGS) $(LINKFLAGS) $(PROFILE) $^ -o $@ $(LIBS)
+-	cp $@ ../../bin
+
+ # executable that is linked to dummy I/O interfaces and that reads only ASCII files
+ wfoverlap_ascii.x : main.f90 $(MAINOBS) $(DUMMYOBS) iomod.o
+ 	$(FC) $(FCFLAGS) $(LINKFLAGS) $(PROFILE) $^ -o $@ $(LALIB)
+-	cp $@ ../../bin
+-	ln -fs $@ ../../bin/wfoverlap.x
+
+ alloc:
+ 	./write_allocmod.pl > my_alloc.f90

--- a/wfoverlap/default.nix
+++ b/wfoverlap/default.nix
@@ -1,0 +1,51 @@
+{ stdenv, lib, fetchFromGitHub, gfortran, blas-i8, lapack-i8 }:
+assert
+  lib.asserts.assertMsg
+  (blas-i8.isILP64 || blas-i8.passthru.implementation == "mkl")
+  "64 bit integer BLAS implementation required.";
+
+assert
+  lib.asserts.assertMsg
+  (lapack-i8.isILP64)
+  "64 bit integer LAPACK implementation required.";
+
+stdenv.mkDerivation rec {
+    pname = "wfoverlap";
+    version = "24.08.2020";
+
+    src =
+      let
+        repo = fetchFromGitHub {
+          owner = "sharc-md";
+          repo = "sharc";
+          rev = "d943ec7aff0fb6c81f61d3c057b0921d053e9e20";
+          sha256 = "1a9frnxvm1jg4cv3jd4lm3q8m7igyc7fsp3baydfjkvk0b4ss9bc";
+        };
+      in "${repo}/wfoverlap/source";
+
+    nativeBuildInputs = [ gfortran ];
+
+    buildInputs = [
+      gfortran
+      blas-i8
+      lapack-i8
+    ];
+
+    patches = [ ./Makefile.patch ];
+
+    dontConfigure = true;
+
+    hardeningDisable = [ "format" ];
+
+    installPhase = ''
+      mkdir -p $out/bin
+      cp wfoverlap.x $out/bin/.
+    '';
+
+    meta = with lib; {
+      description = "Efficient calculation of wavefunction overlaps";
+      license = licenses.gpl3Only;
+      homepage = "https://sharc-md.org/?page_id=309";
+      platforms = platforms.linux;
+    };
+  }


### PR DESCRIPTION
Standalone version of the WFOverlap program, that is included in the sharc distribution or downloadable at [https://sharc-md.org/?page_id=309](https://sharc-md.org/?page_id=309). It requires some tweaks to build without MKL but works flawless then. 

The license is a little bit curious. The entire SHARC repo is under a GPL and the WFOverlap source AND binary is included there. So I would assume a GPL is fine. But in contrast there is also the registration page (see above), with a completely different non-free license. 