### PR TITLE
gamess-us: init at 2021R2P1

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -133,6 +133,10 @@ let
           mpi = super.mpi.override { gfortran = super.gfortran8; };
         };
 
+        gamess-us = callPackage ./pkgs/apps/gamess-us {
+          blas = self.blas-i8;
+        };
+
         gaussview = callPackage ./pkgs/apps/gaussview { };
 
         gdma = callPackage ./pkgs/apps/gdma { };

--- a/pkgs/apps/gamess-us/AuxDataPath.patch
+++ b/pkgs/apps/gamess-us/AuxDataPath.patch
@@ -1,0 +1,13 @@
+diff --git a/gms-files.csh b/gms-files.csh
+index 92d809b..1e8835f 100755
+--- a/gms-files.csh
++++ b/gms-files.csh
+@@ -29,7 +29,7 @@
+ #
+ set echo
+ setenv NO_STOP_MESSAGE 1
+-setenv AUXDATA $GMSPATH/auxdata
++setenv AUXDATA $GMSPATH/../share/gamess/auxdata
+ setenv  EXTBAS /dev/null
+ setenv  NUCBAS /dev/null
+ setenv  EXTCAB $AUXDATA/AUXBAS/auxdef21

--- a/pkgs/apps/gamess-us/default.nix
+++ b/pkgs/apps/gamess-us/default.nix
@@ -1,0 +1,158 @@
+{ stdenv, lib, makeWrapper, fetchFromGitLab, requireFile, gfortran, writeTextFile, cmake, perl
+, tcsh, mpi, blas, hostname, openssh, gnused, libxc, ncurses
+}:
+assert
+  lib.asserts.assertMsg
+  (builtins.elem blas.passthru.implementation [ "mkl" "openblas" ])
+  "The BLAS providers can be either MKL or OpenBLAS.";
+
+assert
+  lib.asserts.assertMsg
+  (blas.isILP64)
+  "A 64 bit integer implementation of BLAS is required.";
+
+stdenv.mkDerivation rec {
+  pname = "gamess-us";
+  version = "2021R2P1";
+
+  # The website always provides "gamess-current.tar.gz". However, we expect the file to be renamed,
+  # to a more reasonable name.
+  src = requireFile rec {
+    name = "${pname}-${version}.tar.gz";
+    sha256 = "36a07e3567eec3b804fca41022b45588645215ccf4557d5176fb69d473b9521c";
+    url = "https://www.msg.chem.iastate.edu/gamess/download.html";
+  };
+
+  patches = [
+    # Launcher scripts, which also contains settings, such as MPI locations and data paths
+    ./rungms.patch
+    # Adaptions to a more nix-like directory structure
+    ./AuxDataPath.patch
+    # Link MKL dynamic libraries, instead of static
+    ./mkl.patch
+  ];
+
+  nativeBuildInputs = [
+    makeWrapper
+    cmake
+    perl
+    hostname
+    gnused
+    ncurses
+  ];
+
+  buildInputs = [
+    gfortran
+    blas
+  ];
+
+  propagatedBuildInputs = [
+    tcsh
+    mpi
+  ];
+
+  postPatch =
+    let
+      # Environment variable required by GAMESS to set correct MPI version in rungms script.
+      mpiname = mpi.pname;
+      mpiroot = builtins.toString mpi;
+    in ''
+      # patchshebangs does not patch /bin/csh, as it does not recognise those. Also /bin/csh appears
+      # in more locations than just shebangs
+      find . -type f -exec sed -i "s!/bin/csh!${tcsh}/bin/tcsh!g" {} \;
+
+      # Increase the maximum numbers of CPUs per node and maximum number of Nodes to a more reasonable
+      # value for DDI
+      substituteInPlace ddi/compddi --replace "set MAXCPUS=32" "set MAXCPUS=256"
+
+      # Prepare the rungms script -> replace references to @version@ and @out@
+      export mpiname=${mpiname}
+      export mpiroot=${mpiroot}
+      substituteAllInPlace rungms
+
+      # Make config accept dynamic OpenBLAS
+      substituteInPlace config --replace "libopenblas.a" "libopenblas.so"
+      substituteInPlace lked --replace "libopenblas.a" "libopenblas.so"
+    '';
+
+  # The interactive config script of gamess. Pretty standard build with MPI parallelism, but
+  # without additional interfaces (such as libxc, qcengine, tinker, ...)
+  configurePhase = ''
+    ./config << EOF
+
+    linux64
+
+
+    ${version}
+    gfortran
+    ${lib.versions.majorMinor gfortran.version}
+
+    ${blas.passthru.implementation}
+    ${blas.passthru.provider}
+    ${if blas.implementation == "mkl"
+       then "proceed"
+       else "${blas.passthru.provider}/lib"
+    }
+
+    mpi
+    ${mpi.pname}
+    ${mpi}
+    no
+    no
+    no
+    no
+    no
+    no
+    no
+    no
+    no
+    no
+    no
+    EOF
+  '';
+
+  makeFlags = [ "ddi" "modules" "gamess" ];
+
+  # Of course also the installation is quite custom ... Take care of the installation.
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/share $out/share/gamess
+
+    # Copy the interesting scripts and executables
+    cp gamess.${version}.x rungms $out/bin/.
+
+    # Copy the file definitions to share
+    cp gms-files.csh $out/share/gamess
+
+    # Copy auxdata, which contains parameters and basis sets
+    cp -r auxdata $out/share/gamess/.
+
+    # Copy the test files
+    cp -r tests $out/share/gamess/.
+
+    runHook postInstall
+  '';
+
+  # Patch the entry point to fit this systems needs for running an actual calculation.
+  postFixup =
+    let binSearchPath = lib.strings.makeSearchPath "bin" [ openssh mpi tcsh hostname ];
+    in ''
+      wrapProgram $out/bin/rungms \
+        --set-default SCRATCH "/tmp" \
+        --set-default OMP_NUM_THREADS 1 \
+        --prefix PATH : ${binSearchPath}
+    '';
+
+  hardeningDisable = [ "format" ];
+
+  passthru = { inherit mpi; };
+
+  meta = with lib; {
+    description = "GAMESS is a program for ab initio molecular quantum chemistry";
+    homepage = "https://www.msg.chem.iastate.edu/gamess/index.html";
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = [ maintainers.sheepforce ];
+  };
+}

--- a/pkgs/apps/gamess-us/default.nix
+++ b/pkgs/apps/gamess-us/default.nix
@@ -123,7 +123,7 @@ stdenv.mkDerivation rec {
     cp gamess.${version}.x rungms $out/bin/.
 
     # Copy the file definitions to share
-    cp gms-files.csh $out/share/gamess
+    cp gms-files.csh $out/share/gamess/.
 
     # Copy auxdata, which contains parameters and basis sets
     cp -r auxdata $out/share/gamess/.
@@ -143,6 +143,15 @@ stdenv.mkDerivation rec {
         --set-default OMP_NUM_THREADS 1 \
         --prefix PATH : ${binSearchPath}
     '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    # MPI fixes in sandbox
+    export HYDRA_IFACE=lo
+    export OMPI_MCA_rmaps_base_oversubscribe=1
+    
+    $out/bin/rungms $out/share/gamess/tests/mcscf/mrpt/parallel/mc-detpt-bic-short.inp ${version} 2 2
+  '';
 
   hardeningDisable = [ "format" ];
 

--- a/pkgs/apps/gamess-us/mkl.patch
+++ b/pkgs/apps/gamess-us/mkl.patch
@@ -1,0 +1,30 @@
+diff --git a/lked b/lked
+index 92c7119..638c2ad 100755
+--- a/lked
++++ b/lked
+@@ -388,9 +388,9 @@ if ($TARGET == linux32) then
+                # next attempts a static link, whereas 10 above is a dynamic link.
+                # if this fails to work, try the version 10 lines shown just above.
+                set MATHLIBS="-Wl,--start-group"
+-               set MATHLIBS="$MATHLIBS $mpath/libmkl_intel.a "
+-               set MATHLIBS="$MATHLIBS $mpath/libmkl_sequential.a "
+-               set MATHLIBS="$MATHLIBS $mpath/libmkl_core.a "
++               set MATHLIBS="$MATHLIBS $mpath/libmkl_intel.so "
++               set MATHLIBS="$MATHLIBS $mpath/libmkl_sequential.so "
++               set MATHLIBS="$MATHLIBS $mpath/libmkl_core.so "
+                set MATHLIBS="$MATHLIBS -Wl,--end-group"
+                breaksw
+             default:
+@@ -656,9 +656,9 @@ if ($TARGET == linux64) then
+                set iflib=intel
+                if (($GMS_FORTRAN == gfortran) || ($GMS_FORTRAN == aocc)) set iflib=gf
+                set MATHLIBS="-Wl,--start-group"
+-               set MATHLIBS="$MATHLIBS $mpath/libmkl_${iflib}_ilp64.a "
+-               set MATHLIBS="$MATHLIBS $mpath/libmkl_sequential.a "
+-               set MATHLIBS="$MATHLIBS $mpath/libmkl_core.a "
++               set MATHLIBS="$MATHLIBS $mpath/libmkl_${iflib}_ilp64.so "
++               set MATHLIBS="$MATHLIBS $mpath/libmkl_sequential.so "
++               set MATHLIBS="$MATHLIBS $mpath/libmkl_core.so "
+                set MATHLIBS="$MATHLIBS -Wl,--end-group"
+                if ($GMS_OPENMP == true) set MATHLIBS="$MATHLIBS -ldl"
+                if (($GMS_FORTRAN == gfortran) || ($GMS_FORTRAN == aocc)) then

--- a/pkgs/apps/gamess-us/rungms.patch
+++ b/pkgs/apps/gamess-us/rungms.patch
@@ -1,0 +1,82 @@
+diff --git a/rungms b/rungms
+index d4cd542..be65ff0 100755
+--- a/rungms
++++ b/rungms
+@@ -80,10 +80,10 @@
+ #       both Sun Grid Engine (SGE), and Portable Batch System (PBS).
+ #       See also a very old LoadLeveler "ll-gms" for some IBM systems.
+ #
+-set TARGET=sockets
+-set SCR=~/gamess/restart
+-set USERSCR=~/gamess/restart
+-set GMSPATH=~/gamess
++set TARGET=mpi
++set SCR=$SCRATCH
++set USERSCR=$SCRATCH
++set GMSPATH=@out@/bin
+ #
+ # Get any MDI-related options and remove them from the argument list
+ #
+@@ -149,7 +149,7 @@ set NCPUS=$3    # number of compute processes to be run
+ set LOGN=$5    # number of cores per logical node
+ #
+ # provide defaults if last two arguments are not given to this script
+-if (null$VERNO == null) set VERNO=00
++if (null$VERNO == null) set VERNO=@version@
+ if (null$NCPUS == null) set NCPUS=1
+ if (null$LOGN == null) set LOGN=0
+ #
+@@ -226,7 +226,7 @@ endif
+ #    define many environment variables setting up file names.
+ #    anything can be overridden by a user's own choice, read 2nd.
+ #
+-source $GMSPATH/gms-files.csh
++source $GMSPATH/../share/gamess/gms-files.csh
+ if (-e $HOME/.gmsrc) then
+    echo "reading your own $HOME/.gmsrc"
+    source $HOME/.gmsrc
+@@ -656,7 +656,7 @@ if ($TARGET == mpi) then
+    #          this will have directories like include/lib/bin below it.
+    #       3. a bit lower, perhaps specify your ifort path information.
+    #
+-   set DDI_MPI_CHOICE=impi
++   set DDI_MPI_CHOICE=@mpiname@
+    #
+    #        ISU's various clusters have various iMPI paths, in this order:
+    #              dynamo/chemphys2011/exalted/bolt/CyEnce/CJ
+@@ -665,7 +665,7 @@ if ($TARGET == mpi) then
+       #-- DDI_MPI_ROOT=/share/apps/intel/impi/4.0.1.007/intel64
+       #-- DDI_MPI_ROOT=/share/apps/intel/impi/4.0.2.003/intel64
+       #-- DDI_MPI_ROOT=/share/apps/mpi/impi/intel64
+-      set DDI_MPI_ROOT=/shared/intel/impi/4.1.0.024/intel64
++      set DDI_MPI_ROOT=@mpiroot@
+       #-- DDI_MPI_ROOT=/share/apps/mpi/impi/intel64
+    endif
+    #
+@@ -676,22 +676,22 @@ if ($TARGET == mpi) then
+       #-- DDI_MPI_ROOT=/share/apps/mpi/mvapich2-1.9a2-qlc
+       #-- DDI_MPI_ROOT=/share/apps/mpi/mvapich2-1.9-generic-gnu
+       #-- DDI_MPI_ROOT=/share/apps/mpi/mvapich2-2.0a-generic
+-      set DDI_MPI_ROOT=/share/apps/mpi/mvapich2-2.1a-mlnx
++      set DDI_MPI_ROOT=@mpiroot@
+    endif
+    #
+    #        ISU's various clusters have various openMPI paths
+    #          examples are our bolt/CyEnce clusters
+    if ($DDI_MPI_CHOICE == openmpi) then
+       #-- DDI_MPI_ROOT=/share/apps/mpi/openmpi-1.6.4-generic
+-      set DDI_MPI_ROOT=/shared/openmpi-1.6.4/intel-13.0.1
++      set DDI_MPI_ROOT=@mpiroot@
+    endif
+    #
+    #   MPICH/MPICH2
+    if ($DDI_MPI_CHOICE == mpich) then
+-      set DDI_MPI_ROOT=/share/apps/share/mpi/mpich-3.1.3-generic-gnu
++      set DDI_MPI_ROOT=@mpiroot@
+    endif
+    if ($DDI_MPI_CHOICE == mpich2) then
+-      set DDI_MPI_ROOT=/share/apps/share/mpi/mpich-3.1.3-generic-gnu
++      set DDI_MPI_ROOT=@mpiroot@
+    endif
+    #
+    #        pre-pend our MPI choice to the library and execution paths.


### PR DESCRIPTION
This is an attempt to add the current GAMESS-US distribution. I've had it working with `nixos-20.09` in my own overlay some time ago. Now building fails during compilation. A script seems simply to fail but I can't figure out why. It fails at `make modules` with `sed: can't read modules_dft: No such file or directory`. I've noticed that you GAMESS-US in the overlay some time ago. @markuskowa could you maybe help me here?