### PR TITLE
pysisyphus: init at 0.7rc1

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -336,6 +336,9 @@ let
       molpro12 = null;
       molpro20 = null;
       molpro-ext = null;
+
+      # Provide null gaussian attrs in case optpath is not set
+      gaussian = null;
     }  // lib.optionalAttrs (cfg.licMolpro != null) {
 
       #

--- a/default.nix
+++ b/default.nix
@@ -188,6 +188,8 @@ let
       psi4 = super.python3.pkgs.toPythonApplication self.python3.pkgs.psi4;
       psi4Unstable = super.python3.pkgs.toPythonApplication self.python3.pkgs.psi4Unstable;
 
+      pysisyphus = super.python3.pkgs.toPythonApplication self.python3.pkgs.pysisyphus;
+
       qdng = callPackage ./pkgs/apps/qdng {
         protobuf=super.protobuf3_11;
       };

--- a/pkgs/apps/nwchem/default.nix
+++ b/pkgs/apps/nwchem/default.nix
@@ -3,7 +3,7 @@
 , automake, autoconf, libtool, makeWrapper
 } :
 
-assert blas.isILP64 == blas.isILP64;
+assert blas.isILP64 == lapack.isILP64;
 
 let
   version = "7.0.2";
@@ -68,7 +68,7 @@ in stdenv.mkDerivation {
   USE_PYTHON64="n";
   PYTHONLIBTYPE="so";
   PYTHONHOME="${python}";
-  PYTHONVERSION="2.7";
+  PYTHONVERSION=lib.versions.majorMinor python.version;
 
   BLASOPT="-L${blas}/lib -lblas";
   LAPACK_LIB="-L${lapack}/lib -llapack";

--- a/pkgs/apps/pyscf/default.nix
+++ b/pkgs/apps/pyscf/default.nix
@@ -4,13 +4,13 @@
 
 buildPythonPackage rec {
   pname = "pyscf";
-  version = "1.7.6";
+  version = "1.7.6.post1";
 
   src = fetchFromGitHub {
     owner = "pyscf";
     repo = pname;
-    rev = "v${version}";
-    sha256  = "1plicf3df732mcwzsinfbmlzwwi40sh2cxy621v7fny2hphh14dl";
+    rev = "f6c9c6654dd9609c5e467a1edd5c2c076f793acc";
+    sha256  = "0xbwkjxxysfpqz72qn6n4a0zr2h6sprbcal8j7kzymh7swjy117w";
   };
 
   buildInputs = [
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     python3
   ];
 
-  PYSCF_INC_DIR="${libcint}:${libxc}";
+  PYSCF_INC_DIR="${libcint}:${libxc}:${xcfun}";
 
   doCheck = false;
 
@@ -36,5 +36,6 @@ buildPythonPackage rec {
     homepage = https://pyscf.github.io/;
     license = licenses.asl20;
     platforms = platforms.linux;
+    maintainers = [ maintainers.sheepforce ];
   };
 }

--- a/pkgs/apps/pysisyphus/default.nix
+++ b/pkgs/apps/pysisyphus/default.nix
@@ -1,0 +1,140 @@
+{ fetchPypi, fetchFromGitHub, buildPythonPackage, lib, writeTextFile, writeScript, makeWrapper,
+ # Python dependencies
+ autograd, dask, distributed, h5py, jinja2, matplotlib, numpy, natsort, pytest, pyyaml, rmsd, scipy,
+ sympy, scikitlearn, qcengine, ase, xtb-python, openbabel-bindings,
+ # Runtime dependencies
+ runtimeShell, jmol, multiwfn, xtb, openmolcas, pyscf, psi4, wfoverlap, nwchem, orca ? null ,
+ turbomole ? null, gaussian ? null, gamess-us ? null, cfour ? null, molpro ? null,
+ # Test dependencies
+ openssh,
+ # Configuration
+ fullTest ? false
+}:
+let
+  psi4Wrapper = writeScript "psi4.sh" ''
+    #!${runtimeShell}
+    ${psi4}/bin/psi4 -o stdout $1
+  '';
+  pysisrc =
+    let
+      gaussian16Conf = {
+        cmd = "${gaussian}/bin/g16";
+        formchk_cmd = "${gaussian}/bin/formchk";
+        unfchk_cmd = "${gaussian}/bin/unfchk";
+      };
+      text = with lib.lists; lib.generators.toINI {} (builtins.listToAttrs ([
+        { name = "openmolcas"; value.cmd = "${openmolcas}/bin/pymolcas"; }
+        { name = "psi4"; value.cmd = "${psi4Wrapper}"; }
+        { name = "wfoverlap"; value.cmd = "${wfoverlap}/bin/wfoverlap.x"; }
+        { name = "multiwfn"; value.cmd = "${multiwfn}/bin/Multiwfn"; }
+        { name = "jmol"; value.cmd = "${jmol}/bin/jmol"; }
+        { name = "xtb"; value.cmd = "${xtb}/bin/xtb"; }
+      ] ++ optional (gaussian != null) { name = "gaussian16"; value = gaussian16Conf; }
+        ++ optional (orca != null) { name = "orca"; value.cmd = "${orca}/bin/orca"; }
+      ));
+    in
+      writeTextFile {
+        inherit text;
+        name = "pysisrc";
+      };
+
+  binSearchPath = with lib; makeSearchPath "bin" ([
+    jmol
+    multiwfn
+    xtb
+    openmolcas
+    pyscf
+    psi4
+    wfoverlap
+    nwchem
+  ] ++ lists.optional (orca != null) orca
+    ++ lists.optional (turbomole != null) turbomole
+    ++ lists.optional (gaussian != null) gaussian
+    ++ lists.optional (cfour != null) cfour
+    ++ lists.optional (molpro != null) molpro
+  );
+
+in
+  buildPythonPackage rec {
+    pname = "pysisyphus";
+    version = "0.7rc1";
+
+    nativeBuildInputs = [ makeWrapper ];
+
+    propagatedBuildInputs = with lib; [
+      autograd
+      dask
+      distributed
+      h5py
+      jinja2
+      matplotlib
+      numpy
+      natsort
+      pyyaml
+      rmsd
+      scipy
+      sympy
+      scikitlearn
+      qcengine
+      ase
+      xtb-python
+      openbabel-bindings
+      pytest # Also required for normal execution
+      # Syscalls
+      jmol
+      multiwfn
+      xtb
+      openmolcas
+      pyscf
+      psi4
+      wfoverlap
+      nwchem
+    ] ++ lists.optional (orca != null) orca
+      ++ lists.optional (turbomole != null) turbomole
+      ++ lists.optional (gaussian != null) gaussian
+      ++ lists.optional (cfour != null) cfour
+      ++ lists.optional (molpro != null) molpro
+    ;
+
+    src = fetchFromGitHub {
+      owner = "eljost";
+      repo = pname;
+      rev = version;
+      sha256 = "19jwn2hprawz652z0q4d716z2gyb2l3vhjkxn4rjr0dhz5ps4nw2";
+    };
+
+    doCheck = true;
+
+    checkInputs = [ pytest openssh ];
+
+    checkPhase = ''
+      export PYSISRC=${pysisrc}
+      export PATH=$PATH:${binSearchPath}
+      export OMPI_MCA_rmaps_base_oversubscribe=1
+
+      echo $PYSISRC
+
+      ${if fullTest
+          then "pytest -v tests --disable-warnings"
+          else "pytest -v --pyargs pysisyphus.tests --disable-warnings"
+      }
+    '';
+
+    postInstall = ''
+      mkdir -p $out/share/pysisyphus
+      cp ${pysisrc} $out/share/pysisyphus/pysisrc
+      for exe in $out/bin/*; do
+        wrapProgram $exe \
+          --prefix PATH : ${binSearchPath} \
+          --set-default "PYSISRC" "$out/share/pysisyphus/pysisrc"
+      done
+    '';
+
+    meta = with lib; {
+      description = "Python suite for optimization of stationary points on ground- and excited states PES and determination of reaction paths";
+      homepage = "https://github.com/eljost/pysisyphus";
+      license = licenses.gpl3;
+      platforms = platforms.linux;
+      maintainers = [ maintainers.sheepforce ];
+    };
+  }

--- a/pkgs/apps/qcelemental/default.nix
+++ b/pkgs/apps/qcelemental/default.nix
@@ -1,45 +1,41 @@
-{ buildPythonPackage, lib, fetchPypi
-# Other dependencies
-, cacert
-# Python dependencies
-, numpy
-, pydantic
-, pint
-, networkx
-, pytestrunner
-, pytestcov
-, pytest
+{ buildPythonPackage, lib, fetchPypi, fetchpatch, numpy
+, pydantic, pint,  networkx, pytestrunner, pytestcov, pytest
 } :
 
 buildPythonPackage rec {
   pname = "qcelemental";
-  version = "0.19.0";
+  version = "0.20.0";
 
-  checkInputs = [
-    pytestrunner
-    pytestcov
-    pytest
-  ];
-
-  propagatedBuildInputs = [
-    numpy
-    pydantic
-    pint
-    networkx
-    cacert
-  ];
+  checkInputs = [ pytestrunner pytestcov pytest ];
+  propagatedBuildInputs = [ numpy pydantic pint networkx ];
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1ljxwhiz1689qijjqzmzydn8q963xx7zxizjnjq0vqg5py9pkyc5";
+    sha256 = "141vw36fmacj897q26kq2bl9l0d23lyqjfry6q46aa9087dcs7ni";
   };
+
+  # FIXME: Fixed upstream but not released yet. Nevertheless critical for correct behaviour.
+  # See https://github.com/MolSSI/QCElemental/pull/265
+  patches = [
+    (fetchpatch {
+      name = "SearchPath1.patch";
+      url = "https://github.com/MolSSI/QCElemental/commit/2211a4e59690bcb14265a60f199a5efe74fe44db.diff";
+      sha256 = "1ibjvmdrc103jdj79xrr11y5yji5hc966rm4ihfhfzgbvfkbjg2l";
+    })
+    (fetchpatch {
+      name = "SearchPath2.patch";
+      url = "https://github.com/MolSSI/QCElemental/commit/5a32ce33e8142047b0a00d0036621fe2750e872a.diff";
+      sha256 = "0gmg70vdps7k6alqclwdlxkli9d8s1fphbdvyl8wy8xrh46jw6rk";
+    })
+  ];
 
   doCheck = true;
 
   meta = with lib; {
-    description = "Periodic table, physical constants, and molecule parsing for quantum chemistry.";
+    description = "Periodic table, physical constants, and molecule parsing for quantum chemistry";
     homepage = "http://docs.qcarchive.molssi.org/projects/qcelemental/en/latest/";
     license = licenses.bsd3;
     platforms = platforms.linux;
+    maintainers = [ maintainers.sheepforce ];
   };
 }

--- a/pkgs/apps/qcengine/default.nix
+++ b/pkgs/apps/qcengine/default.nix
@@ -1,18 +1,10 @@
-{ buildPythonPackage, lib, fetchPypi
-, pyyaml
-, qcelemental
-, pydantic
-, py-cpuinfo
-, psutil
-, cacert
-, pytestrunner
-, pytest
-, pytestcov
+{ buildPythonPackage, lib, fetchPypi, pyyaml, qcelemental, pydantic
+, py-cpuinfo, psutil, pytestrunner, pytest, pytestcov
 } :
 
 buildPythonPackage rec {
   pname = "qcengine";
-  version = "0.17.0";
+  version = "0.19.0";
 
   checkInputs = [
     pytestrunner
@@ -21,7 +13,6 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
-    cacert
     pyyaml
     qcelemental
     pydantic
@@ -31,15 +22,16 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "19a2ca5a341514f8f6c491e7570ecd4e98cf31290bd34d47a475722100cc971d";
+    sha256 = "0lz9r0fh31mcixdhayiwfc69cp8if9b3nkrk7gxdrb6vhbfrxhij";
   };
 
   doCheck = true;
 
   meta = with lib; {
-    description = "Quantum chemistry program executor and IO standardizer (QCSchema) for quantum chemistry.";
+    description = "Quantum chemistry program executor and IO standardizer (QCSchema) for quantum chemistry";
     homepage = "http://docs.qcarchive.molssi.org/projects/qcelemental/en/latest/";
     license = licenses.bsd3;
-    platforms = platforms.linux;
+    platforms = [ "x86_64-linux" ];
+    maintainers = [ maintainers.sheepforce ];
   };
 }

--- a/pkgs/lib/rmsd/default.nix
+++ b/pkgs/lib/rmsd/default.nix
@@ -1,0 +1,20 @@
+{ buildPythonPackage, lib, fetchPypi, scipy }:
+buildPythonPackage rec {
+    pname = "rmsd";
+    version = "1.4";
+
+    propagatedBuildInputs = [ scipy ];
+
+    src = fetchPypi  {
+      inherit pname version;
+      sha256 = "0gsncsszya1zp2yw777f46df2a3wk80d8np5c4ihzalzj5glma0n";
+    };
+
+    meta = with lib; {
+      description = "Calculate root-mean-square deviation (RMSD) between two sets of cartesian coordinates";
+      homepage = "https://github.com/charnley/rmsd";
+      license = licenses.bsd2;
+      platforms = platforms.linux;
+      maintainers = [ maintainers.sheepforce ];
+    };
+  }

--- a/pkgs/lib/xtb-python/default.nix
+++ b/pkgs/lib/xtb-python/default.nix
@@ -1,0 +1,51 @@
+{ buildPythonPackage, lib, fetchFromGitHub, cffi, numpy, ase, qcelemental, meson, ninja, pkg-config,
+  xtb, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "xtb-python";
+  version = "20.2";
+
+  src = fetchFromGitHub {
+    owner = "grimme-lab";
+    repo = pname;
+    rev = "v${version}";
+    sha256  = "0ra4d4hi34clckxy9nv0k3ignjcfa7vv1w33y854zqk9qr45z4bg";
+  };
+
+  postPatch = ''
+    cp -r ${xtb.src} subprojects/.
+  '';
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  propagatedBuildInputs = [
+    cffi
+    numpy
+    ase
+    qcelemental
+    xtb
+  ];
+
+  # Build a C module to interface XTB.
+  preBuild = ''
+    meson setup build --prefix=$PWD --default-library=shared
+    ninja -C build install
+  '';
+
+  checkInputs = [ pytest ];
+  checkPhase = "pytest";
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Python wrapper for the semiempirical XTB package";
+    homepage = "https://github.com/grimme-lab/xtb-python";
+    license = licenses.lgpl3Only;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.sheepforce ];
+  };
+}

--- a/pythonPackages.nix
+++ b/pythonPackages.nix
@@ -52,7 +52,7 @@ let
       orca = selfPkgs.orca;
       turbomole = selfPkgs.turbomole;
       cfour = selfPkgs.cfour;
-      #gaussian = selfPkgs.gaussian;
+      gaussian = selfPkgs.gaussian;
       molpro = selfPkgs.molpro;
     };
 

--- a/pythonPackages.nix
+++ b/pythonPackages.nix
@@ -47,6 +47,8 @@ let
       rev = "9b60184c5d161e4871c91ce29a44e3ac2c2a438e";
       sha256 = "1vh8dp3nw4fk1mnfv0w8ici1lzxyfn5han7hipqzsfxl75w76r18";
     };
+    rmsd = callPackage ./pkgs/lib/rmsd { };
+
     xtb-python = callPackage ./pkgs/lib/xtb-python { };
   } // lib.optionalAttrs super.isPy27 {
     pyquante = callPackage ./pkgs/apps/pyquante { };

--- a/pythonPackages.nix
+++ b/pythonPackages.nix
@@ -47,6 +47,7 @@ let
       rev = "9b60184c5d161e4871c91ce29a44e3ac2c2a438e";
       sha256 = "1vh8dp3nw4fk1mnfv0w8ici1lzxyfn5han7hipqzsfxl75w76r18";
     };
+    xtb-python = callPackage ./pkgs/lib/xtb-python { };
   } // lib.optionalAttrs super.isPy27 {
     pyquante = callPackage ./pkgs/apps/pyquante { };
   };

--- a/pythonPackages.nix
+++ b/pythonPackages.nix
@@ -47,6 +47,15 @@ let
       rev = "9b60184c5d161e4871c91ce29a44e3ac2c2a438e";
       sha256 = "1vh8dp3nw4fk1mnfv0w8ici1lzxyfn5han7hipqzsfxl75w76r18";
     };
+
+    pysisyphus = callPackage ./pkgs/apps/pysisyphus {
+      orca = selfPkgs.orca;
+      turbomole = selfPkgs.turbomole;
+      cfour = selfPkgs.cfour;
+      #gaussian = selfPkgs.gaussian;
+      molpro = selfPkgs.molpro;
+    };
+
     rmsd = callPackage ./pkgs/lib/rmsd { };
 
     xtb-python = callPackage ./pkgs/lib/xtb-python { };


### PR DESCRIPTION
This adds Pysisyphus for geometry optimisaiton methods. It implements optimisations with wavefunction root tracking, chain of state methods, AFIR and more methods for transition, ground and excited state optimisations. Pysisyphus wraps many other QC programs to obtain forces and is somehow difficult to setup without nix.

As PySCF currently fails to build for my, this PR is blocked by #29 .

This and the GAMESS-US PR #28 are the last package additions from my list. :slightly_smiling_face: :partying_face: 