### PR TITLE
cp2k: fix openmp threading

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -118,7 +118,7 @@ let
 
       chemps2 = callPackage ./chemps2 {};
 
-      cp2k = callPackage ./cp2k rec {
+      cp2k = callPackage ./cp2k {
         libxc = self.libxc4;  # patches are are required for libxc5
         inherit optAVX;
       };

--- a/default.nix
+++ b/default.nix
@@ -118,7 +118,7 @@ let
 
       chemps2 = callPackage ./chemps2 {};
 
-      cp2k = callPackage ./cp2k {
+      cp2k = callPackage ./cp2k rec {
         libxc = self.libxc4;  # patches are are required for libxc5
         inherit optAVX;
       };
@@ -221,7 +221,7 @@ let
       vmd = callPackage ./vmd {};
 
       wfoverlap = callPackage ./wfoverlap {};
-        
+
       xtb = callPackage ./xtb {
         turbomole = null;
         cefine = null;

--- a/tests/cp2k/default.nix
+++ b/tests/cp2k/default.nix
@@ -24,7 +24,7 @@ in batsTest {
 
   testScript = lib.concatStringsSep "\n" ( map (x: ''
     @test "${x}" {
-      ${mpi}/bin/mpirun -np $TEST_NUM_CPUS ${cp2k}/bin/cp2k ${inp}/${x}.inp > ${x}.out
+      ${mpi}/bin/mpirun -np $TEST_NUM_CPUS ${cp2k}/bin/cp2k.psmp ${inp}/${x}.inp > ${x}.out
     }
   '') [ "dbcsr" "bench_dftb" "H2O-gga" ]) + ''
 


### PR DESCRIPTION
This works around threading problems in CP2K for the PSMP version (see #33). Depending on the BLAS and LAPACK providers either the `psmp` version (for MKL only) or the `popt` version (for anything else) is built.

In principle it also should work with OpenBLAS, at least I've used CP2K 7.1 with OpenBLAS in the PSMP version on our cluster.