### PR TITLE
mvapich: allow for different network types

### DIFF
--- a/mvapich/default.nix
+++ b/mvapich/default.nix
@@ -1,9 +1,28 @@
 { lib, stdenv, fetchurl, pkgconfig, bison, numactl, libxml2
-, perl, gfortran, slurm, openssh, hwloc, rdma-core
-, infiniband-diags, opensm, zlib
+, perl, gfortran, slurm, openssh, hwloc, zlib, makeWrapper
+# InfiniBand dependencies
+, infiniband-diags, opensm, rdma-core
+# OmniPath dependencies
+, libpsm2, libfabric
 # Compile with slurm as a process manager
 , useSlurm ? false
+# Network type for MVAPICH2
+, network ? "ethernet"
 } :
+
+assert builtins.elem network [ "ethernet" "infiniband" "omnipath" ];
+
+assert
+  (if network == "infiniband"
+     then (lib.lists.all (x: x != null) [ infiniband-diags opensm rdma-core ])
+     else true
+  );
+
+assert
+  (if network == "omnipath"
+     then (lib.lists.all (x: x != null) [ libpsm2 libfabric ])
+     else true
+  );
 
 let
 
@@ -23,15 +42,35 @@ in stdenv.mkDerivation rec {
   ];
 
 
-  nativeBuildInputs = [ pkgconfig bison ];
+  nativeBuildInputs = [ pkgconfig bison makeWrapper ];
   propagatedBuildInputs = [ numactl rdma-core zlib infiniband-diags opensm ];
-  buildInputs = [ numactl libxml2
-                  perl gfortran
-                  slurm openssh
-                  hwloc rdma-core
-                  infiniband-diags opensm ];
+  buildInputs = [
+    numactl
+    libxml2
+    perl
+    gfortran
+    slurm
+    openssh
+    hwloc
+    rdma-core
+    infiniband-diags
+    opensm
+    libpsm2
+    libfabric
+  ];
 
-  configureFlags = lib.optionals useSlurm [ "--with-pmi=pmi1" "--with-pm=slurm" ];
+  configureFlags = [
+    "--with-pm=hydra"
+    "--enable-fortran=all"
+    "--enable-cxx"
+    "--enable-threads=multiple"
+    "--enable-hybrid"
+    "--enable-shared"
+  ] ++ lib.optionals useSlurm [ "--with-pmi=pmi1" "--with-pm=slurm" ]
+    ++ lib.optional (network == "ethernet") "--with-device=ch3:sock"
+    ++ lib.optionals (network == "infiniband") [ "--with-device=ch3:mrail" "--with-rdma=gen2" ]
+    ++ lib.optionals (network == "omnipath") ["--with-device=ch3:psm" "--with-psm2=${libpsm2}"]
+  ;
 
   doCheck = true;
 
@@ -40,6 +79,16 @@ in stdenv.mkDerivation rec {
     for entry in $out/bin/mpichversion $out/bin/mpivars; do
       echo "fix rpath: $entry"
       patchelf --set-rpath "$out/lib" $entry
+    done
+  '';
+
+  # Make OpenSSH available, which is required for mpirun_rsh.
+  # Enables hybrid parallelisation scheme by default.
+  postFixup = ''
+    for exe in $out/bin/*; do
+      wrapProgram $exe\
+        --prefix PATH : "${openssh}/bin" \
+        --set-default MV2_ENABLE_AFFINITY "0"
     done
   '';
 


### PR DESCRIPTION
Adds options to MVAPICH to be used with different network types (ethernet, Infiniband and Intel's OmniPath). The test suite of MVAPICH passes but my two test cases (scalapack and Dalton) do not work properly with it. Both segfault (scalapack only for a few tests, not for all). I am not certain why. The [derivation that I've used in my overlay](https://gitlab.com/theoretical-chemistry-jena/nixwithchemistry/-/blob/master/pkgs/libs/mvapich2/default.nix) is very similar and didn't segfault, but I also ever used only nixos-20.09 channel. I am not entirely sure if this is again a threading problem with BLAS. @markuskowa Do you have any suggestion for a package, that uses MPI but not BLAS and LAPACK, where I could narrow this down? It is at least not one of the `configureFlags` of the derivation. I've also tried with only `--with-device=ch3:sock` and nothing else to be able to run anything on my workstation , but this still segfaults.

Update: also segfaults for nixos-20.09