### PR TITLE
Openmolcas Tag Fix & MKL Support

### DIFF
--- a/pkgs/apps/openmolcas/MKL-MPICH.patch
+++ b/pkgs/apps/openmolcas/MKL-MPICH.patch
@@ -1,0 +1,24 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 276ae4e..5e56176 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1304,9 +1304,9 @@ if (LINALG STREQUAL "MKL")
+       endif ()
+     else ()
+       if (ADDRMODE EQUAL 64)
+-        set (libpath "${MKLROOT}/lib/intel64")
++        set (libpath "${MKLROOT}/lib")
+       elseif (ADDRMODE EQUAL 32)
+-        set (libpath "${MKLROOT}/lib/ia32")
++        set (libpath "${MKLROOT}/lib")
+       endif ()
+     endif ()
+     set (MKL_LIBRARY_PATH ${libpath} CACHE PATH "location of MKL libraries." FORCE)
+@@ -1380,7 +1380,7 @@ if (LINALG STREQUAL "MKL")
+     find_library (LIBMKL_BLACS NAMES "mkl_blacs_intelmpi_ilp64"
+                   PATHS ${MKL_LIBRARY_PATH} NO_DEFAULT_PATH)
+   elseif (MPI_IMPLEMENTATION STREQUAL "mpich")
+-    find_library (LIBMKL_BLACS NAMES "mkl_blacs_ilp64"
++    find_library (LIBMKL_BLACS NAMES "mkl_blacs_intelmpi_ilp64"
+                   PATHS ${MKL_LIBRARY_PATH} NO_DEFAULT_PATH)
+   endif ()

--- a/pkgs/apps/openmolcas/v20.10.nix
+++ b/pkgs/apps/openmolcas/v20.10.nix
@@ -4,7 +4,7 @@
 } :
 
 let
-  version = "20.10";
+  version = "20.10-14.10.2020";
   gitLabRev = "v${version}";
 
   python = python3.withPackages (ps : with ps; [ six pyparsing ]);
@@ -32,6 +32,7 @@ in stdenv.mkDerivation {
     url = "https://raw.githubusercontent.com/NixOS/nixpkgs/2eee4e4eac851a2846515dcfa3274c4ab92ecbe5/pkgs/applications/science/chemistry/openmolcas/openblasPath.patch";
     sha256 = "0l6z5zhfbfpbp9x58228nhhwwp1fzmi8cmmasvzddp84h31f0b8h";
   })
+    ./MKL-MPICH.patch
   ];
 
   prePatch = ''

--- a/pkgs/apps/openmolcas/v20.10.nix
+++ b/pkgs/apps/openmolcas/v20.10.nix
@@ -23,8 +23,8 @@ in stdenv.mkDerivation {
   src = fetchFromGitLab {
     owner = "Molcas";
     repo = "OpenMolcas";
-    rev = gitLabRev;
-    sha256 = "1w8av44dx5r9yp2xhf9ypdrhappvk984wrd5pa1ww0qv6j2446ic";
+    rev = "01fe7a2bdca51c51d183f3061b0ee9c631bf9bec";
+    sha256 = "0xr9plgb0cfmxxqmd3wrhvl0hv2jqqfqzxwzs1jysq2m9cxl314v";
   };
 
   patches = [ (fetchpatch {
@@ -126,4 +126,3 @@ in stdenv.mkDerivation {
     platforms = platforms.linux;
   };
 }
-

--- a/pkgs/apps/openmolcas/v21.02.nix
+++ b/pkgs/apps/openmolcas/v21.02.nix
@@ -14,7 +14,7 @@ assert
   "OpenMolcas requires OpenBLAS or MKL.";
 
 let
-  version = "21.02";
+  version = "21.02-24.02.2021";
 
   python = python3.withPackages (ps : with ps; [ six pyparsing ]);
 
@@ -41,6 +41,7 @@ in stdenv.mkDerivation {
     url = "https://raw.githubusercontent.com/NixOS/nixpkgs/2eee4e4eac851a2846515dcfa3274c4ab92ecbe5/pkgs/applications/science/chemistry/openmolcas/openblasPath.patch";
     sha256 = "0l6z5zhfbfpbp9x58228nhhwwp1fzmi8cmmasvzddp84h31f0b8h";
   })
+    ./MKL-MPICH.patch
   ];
 
   prePatch = ''
@@ -48,13 +49,6 @@ in stdenv.mkDerivation {
     cp -r ${srcLibwfa} External/libwfa
     chmod -R u+w External/
   '';
-
-  postPatch = ''
-    substituteInPlace CMakeLists.txt \
-      --replace 'set (libpath "''${MKLROOT}/lib/intel64")' 'set (libpath "''${MKLROOT}/lib")' \
-      --replace 'find_library (LIBMKL_BLACS NAMES "mkl_blacs_ilp64"' 'find_library (LIBMKL_BLACS NAMES "mkl_blacs_intelmpi_ilp64"'
-  '';
-
 
   nativeBuildInputs = [ perl cmake texlive.combined.scheme-minimal makeWrapper ];
   buildInputs = [


### PR DESCRIPTION
Now that I have a running Hydra I noticed that OpenMolcas 20.10 does not build. The Molcas version hashes are not stable. `v20.10` was moved to a different commit multiple times (which one does not realise if the sources are cached in the store). I fixed this by pinning to the current commit hash of the tags, as the tags of molcas are not really stable. For the current molcas 21.02 i also enabled building with MKL.