### PR TITLE
sharcV21: fix version and add more engines

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -210,9 +210,10 @@ let
       sharcV21 = callPackage ./pkgs/apps/sharc/21.nix {
         bagel = self.bagel-serial;
         molcas = self.molcas;
-        molpro = self.molpro12; # V2 only compatible with versions up to 2012
-        useMolpro = if cfg.licMolpro != null then true else false;
-        useOrca = if cfg.srcurl != null then true else false;
+        molpro = if cfg.licMolpro != null then self.molpro12 else null; # V2 only compatible with versions up to 2012
+        orca = self.orca;
+        gaussian = if cfg.optpath != null then self.gaussian else null;
+        turbomole = self.turbomole;
       };
 
       stream-benchmark = callPackage ./pkgs/apps/stream { };


### PR DESCRIPTION
The versioning tag for SHARC 2.1 was changed in the upstream GitHub repo and therefore this version does currently not build on master. This has been fixed. I've used the opportunity to add Turbomole and Gaussian to the supported engines and pass the WFoverlap, that we are building anyway.