### PR TITLE
Sharc Fixes

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -161,6 +161,8 @@ let
 
       molcas = self.molcas2102;
 
+      molcas1809 = callPackage ./pkgs/apps/openmolcas/v18.09.nix { };
+
       molcas2010 = callPackage ./pkgs/apps/openmolcas/v20.10.nix { };
 
       molcas2102 = callPackage ./pkgs/apps/openmolcas/v21.02.nix { };

--- a/pkgs/apps/openmolcas/MKL-18.09.patch
+++ b/pkgs/apps/openmolcas/MKL-18.09.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a4071fd9b..9fb7be99c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1166,7 +1166,7 @@ if (LINALG STREQUAL "MKL")
+                 set (MKL_INCLUDE_PATH "${MKLROOT}/include" CACHE PATH
+                         "location of MKL include files." FORCE)
+                 if (ADDRMODE EQUAL 64)
+-                        set (libpath "${MKLROOT}/lib/intel64")
++                        set (libpath "${MKLROOT}/lib")
+                 elseif (ADDRMODE EQUAL 32)
+                         set (libpath "${MKLROOT}/lib/ia32")
+                 endif ()

--- a/pkgs/apps/openmolcas/v18.09.nix
+++ b/pkgs/apps/openmolcas/v18.09.nix
@@ -1,0 +1,152 @@
+{ lib, stdenv, pkgs, fetchFromGitLab, fetchpatch, cmake, gfortran, perl
+, blas-i8, hdf5-full, python3, texlive, symlinkJoin
+, armadillo, makeWrapper, fetchFromGitHub, chemps2
+} :
+
+assert
+  lib.asserts.assertMsg
+  (blas-i8.isILP64 || blas-i8.passthru.implementation == "mkl")
+  "A 64 int integer BLAS implementation is required.";
+
+assert
+  lib.asserts.assertMsg
+  (builtins.elem blas-i8.passthru.implementation [ "openblas" "mkl" ])
+  "OpenMolcas requires OpenBLAS or MKL.";
+
+let
+  version = "18.09-02.09.2018";
+
+  python = python3.withPackages (ps : with ps; [ six pyparsing ]);
+
+  srcLibwfa = fetchFromGitHub {
+    owner = "libwfa";
+    repo = "libwfa";
+    rev = "efd3d5bafd403f945e3ea5bee17d43e150ef78b2";
+    sha256 = "0qzs8s0pjrda7icws3f1a55rklfw7b94468ym5zsgp86ikjf2rlz";
+  };
+
+in stdenv.mkDerivation {
+  pname = "openmolcas";
+  inherit version;
+
+  src = fetchFromGitLab {
+    owner = "Molcas";
+    repo = "OpenMolcas";
+    rev = "4df62e6695a3942a7acd3bf86af1001a164154ca";
+    sha256 = "1y4dq6ddrrqyagppzn0gpjf81nhgkkla9rxp4r5k0qkyzg483d9r";
+  };
+
+  patches = [
+    ./MKL-18.09.patch
+  ];
+
+  prePatch = ''
+    rm -r External/libwfa
+    cp -r ${srcLibwfa} External/libwfa
+    chmod -R u+w External/
+  '';
+
+
+  nativeBuildInputs = [ perl cmake texlive.combined.scheme-minimal makeWrapper ];
+  buildInputs = [
+    gfortran
+    (blas-i8.passthru.provider)
+    hdf5-full
+    python
+    armadillo
+    chemps2
+  ];
+
+  # tests are not running right now.
+  doCheck = false;
+
+  doInstallCheck = true;
+
+  enableParallelBuilding = true;
+
+  NIX_CFLAGS_COMPILE = "-DH5_USE_110_API";
+
+  cmakeFlags = [
+    "-DOPENMP=ON"
+    "-DTOOLS=ON"
+    "-DHDF5=ON"
+    "-DFDE=ON"
+    "-DWFA=ON"
+    "-DCTEST=ON"
+    "-DCHEMPS2=ON" "-DCHEMPS2_DIR=${chemps2}/bin"
+  ] ++ lib.lists.optionals (blas-i8.passthru.implementation == "openblas") [
+         "-DOPENBLASROOT=${symlinkJoin {
+             name = "openblas";
+             paths = [ blas-i8.passthru.provider.all ];
+           }}"
+         "-DLINALG=OpenBLAS" ]
+    ++ lib.lists.optionals (blas-i8.passthru.implementation == "mkl") [
+         "-DMKLROOT=${blas-i8.passthru.provider}"
+         "-DLINALG=MKL"
+         "-DMKL_LIBRARY_PATH=${blas-i8.passthru.provider}/lib"
+         "-DLIBMKL_CORE=${blas-i8.passthru.provider}/lib/libmkl_core.so"
+       ]
+  ;
+
+  postConfigure = ''
+    # The Makefile will install pymolcas during the build grrr.
+    mkdir -p $out/bin
+    export PATH=$PATH:$out/bin
+  '';
+
+  postFixup = ''
+    # Wrong store path in shebang (no Python pkgs), force re-patching
+    sed -i "1s:/.*:/usr/bin/env python:" $out/bin/pymolcas
+    patchShebangs $out/bin
+
+    wrapProgram $out/bin/pymolcas \
+      --set MOLCAS $out \
+      --prefix PATH : "${chemps2}/bin"
+  '';
+
+  installCheckPhase = ''
+     #
+     # Minimal check if installation runs properly
+     #
+
+     export OMPI_MCA_rmaps_base_oversubscribe=1
+
+     export MOLCAS_WORKDIR=./
+     inp=water
+
+     cat << EOF > $inp.xyz
+     3
+     Angstrom
+     O       0.000000  0.000000  0.000000
+     H       0.758602  0.000000  0.504284
+     H       0.758602  0.000000 -0.504284
+     EOF
+
+     cat << EOF > $inp.inp
+     &GATEWAY
+     coord=water.xyz
+     basis=sto-3g
+     &SEWARD
+     &SCF
+     EOF
+
+     $out/bin/pymolcas $inp.inp > $inp.out
+
+     echo "Check for sucessful run:"
+     grep "Happy landing" $inp.status
+     echo "Check for correct energy:"
+     grep "Total SCF energy" $inp.out | grep 74.880174
+  '';
+
+  checkPhase = ''
+    make test
+  '';
+
+  meta = with lib; {
+    description = "Quantum chemistry software package";
+    homepage = https://gitlab.com/Molcas/OpenMolcas;
+    maintainers = [ maintainers.markuskowa ];
+    license = licenses.lgpl21;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/apps/sharc/21.nix
+++ b/pkgs/apps/sharc/21.nix
@@ -5,7 +5,7 @@
 } :
 
 let
-  version = "2.1";
+  version = "2.1.1";
   python = python2.withPackages(p: with p; [ numpy pyquante ]);
 
 in stdenv.mkDerivation {
@@ -16,7 +16,7 @@ in stdenv.mkDerivation {
     owner = "sharc-md";
     repo = "sharc";
     rev = "v${version}";
-    sha256 = "1p9byiwlyqhbwdq0icxg75n3waxji0fiwp92q8jgrzb384k3bj36";
+    sha256 = "09a5a0zbkganvx9g70vcjbr0i77a9kh095vgh0k0rm0lmkay1cd2";
   };
 
   nativeBuildInputs = [ makeWrapper which ];
@@ -27,6 +27,8 @@ in stdenv.mkDerivation {
     ./testing.patch
     # Molpro tests require more memory
     ./molpro_tests.patch
+    # Allows for newer molcas versions
+    ./molcas_version.patch
   ];
 
   postPatch = ''
@@ -75,9 +77,9 @@ in stdenv.mkDerivation {
                      --set-default MOLCAS ${molcas} \
                      --set-default BAGEL ${bagel} \
                      ${lib.optionalString (molpro != null) "--set-default MOLPRO ${molpro}/bin"} \
-                     ${lib.optionalString (orca != null) "--set-default ORCA ${orca}/bin"} \
+                     ${lib.optionalString (orca != null) "--set-default ORCADIR ${orca}/bin"} \
                      ${lib.optionalString (turbomole != null) "--set-default TURBOMOLE ${turbomole}/bin"} \
-                     ${lib.optionalString (gaussian != null) "--set-default GAUSSIAN ${turbomole}/bin"}
+                     ${lib.optionalString (gaussian != null) "--set-default GAUSSIAN ${gaussian}/bin"}
     done
   '';
 
@@ -90,6 +92,10 @@ in stdenv.mkDerivation {
        sed -i 's/cd \$COPY_DIR/cd $COPY_DIR\;chmod -R +w \*/' $i
     done
   '';
+
+  setupHooks = [
+    ./sharcHook.sh
+  ];
 
   meta = with lib; {
     description = "Molecular dynamics (MD) program suite for excited states";

--- a/pkgs/apps/sharc/molcas_version.patch
+++ b/pkgs/apps/sharc/molcas_version.patch
@@ -1,0 +1,13 @@
+diff --git a/bin/SHARC_MOLCAS.py b/bin/SHARC_MOLCAS.py
+index c49da01..5d61d1f 100755
+--- a/bin/SHARC_MOLCAS.py
++++ b/bin/SHARC_MOLCAS.py
+@@ -873,7 +873,7 @@ def makermatrix(a,b):
+ 
+ # ======================================================================= #
+ def getversion(out,MOLCAS):
+-    allowedrange=[ (18.0,18.999), (8.29999,8.30001) ]
++    allowedrange=[ (18.0,21.02), (8.29999,8.30001) ]
+     # first try to find $MOLCAS/.molcasversion
+     molcasversion=os.path.join(MOLCAS,'.molcasversion')
+     if os.path.isfile(molcasversion):

--- a/pkgs/apps/sharc/sharcHook.sh
+++ b/pkgs/apps/sharc/sharcHook.sh
@@ -1,0 +1,1 @@
+export SHARC=@out@/bin


### PR DESCRIPTION
This PR readds the surprisingly young version 2.1.1 (the tag exists now again ...) of SHARC, adds formal compatibility with current OpenMolcas and exports the `$SHARC` environment by means of a setupHook. Closes #47 

There is also OpenMolcas 18.09 now, which is the officially supported version in SHARC.