### PR TITLE
mpi: cleanup propagation of mpi paths, remove wrappers

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -73,8 +73,6 @@ let
       });
 
       fftw-mpi = self.fftw.overrideAttrs (oldAttrs: {
-        buildInputs = oldAttrs.buildInputs ++ [ self.mpi ];
-
         configureFlags = oldAttrs.configureFlags ++ [
           "--enable-mpi"
           "MPICC=${self.mpi}/bin/mpicc"

--- a/pkgs/apps/bagel/default.nix
+++ b/pkgs/apps/bagel/default.nix
@@ -27,8 +27,11 @@ in stdenv.mkDerivation {
   };
 
   nativeBuildInputs = [ autoconf automake libtool openssh boost ];
-  buildInputs = [ python boost libxc blas mpi ]
+  buildInputs = [ python boost libxc blas ]
                 ++ lib.optional withScalapack scalapack;
+
+  propagatedBuildInputs = [ mpi ];
+  propagatedUserEnvPkgs = [ mpi ];
 
   #
   # Furthermore, if relativistic calculations fail without MKL,
@@ -58,20 +61,7 @@ in stdenv.mkDerivation {
 
   enableParallelBuilding = true;
 
-  postInstall = lib.optionalString (mpi != null) ''
-    cat << EOF > $out/bin/bagel
-    if [ \$# -lt 1 ]; then
-    echo
-    echo "Usage: $(basename \\$0) [mpirun parameters] <input file>"
-    echo
-    exit
-    fi
-    ${mpi}/bin/mpirun \''${@:1:\$#-1} $out/bin/BAGEL \''${@:\$#}
-    EOF
-    chmod 755 $out/bin/bagel
-
-    ''
-    + ''
+  postInstall = ''
     # install test jobs
     mkdir -p $out/share/tests
     cp test/* $out/share/tests

--- a/pkgs/apps/cp2k/default.nix
+++ b/pkgs/apps/cp2k/default.nix
@@ -32,10 +32,12 @@ in stdenv.mkDerivation rec {
     libxc
     libxsmm
     spglib
-    mpi
     scalapack
     mkl
   ];
+
+  propagatedBuildInputs = [ mpi ];
+  propagatedUserEnvPkgs = [ mpi ];
 
   makeFlags = [
     "ARCH=${arch}"
@@ -106,9 +108,6 @@ in stdenv.mkDerivation rec {
       --set OMP_NUM_THREADS 1
 
     cp -r data/* $out/share/cp2k
-
-    ln -s ${mpi}/bin/mpirun $out/bin/mpirun
-    ln -s ${mpi}/bin/mpiexec $out/bin/mpiexec
   '';
 
   passthru = { inherit mpi; };

--- a/pkgs/apps/osu-benchmark/default.nix
+++ b/pkgs/apps/osu-benchmark/default.nix
@@ -12,7 +12,8 @@ in stdenv.mkDerivation {
     sha256 = "1f5fc252c0k4rd26xh1v5017wfbbsr2w7jm49x8yigc6n32sisn5";
   };
 
-  buildInputs = [ mpi ];
+  propagatedBuildInputs = [ mpi ];
+  propagatedUserEnvPkgs = [ mpi ];
 
   preConfigure = ''
     export CXX="${mpi}/bin/mpicc"

--- a/pkgs/lib/sos/default.nix
+++ b/pkgs/lib/sos/default.nix
@@ -21,8 +21,9 @@ in stdenv.mkDerivation {
     "--with-ofi=${libfabric}"
   ];
 
-  nativeBuildInputs = [ autoconf automake libtool mpi openssh ];
+  nativeBuildInputs = [ autoconf automake libtool openssh ];
   buildInputs = [ rdma-core libfabric libnl perl ];
+  propagatedBuildInputs = [ mpi ];
 
   enableParallelBuilding = true;
 

--- a/tests/bagel/bench-test.nix
+++ b/tests/bagel/bench-test.nix
@@ -11,7 +11,7 @@ batsTest {
 
   testScript = ''
     @test "Run-Bagel" {
-      ${bagel}/bin/bagel -np $TEST_NUM_CPUS ./bagel.inp > bagel.out
+      mpirun -np $TEST_NUM_CPUS ${bagel}/bin/BAGEL ./bagel.inp > bagel.out
     }
   '';
 

--- a/tests/bagel/default.nix
+++ b/tests/bagel/default.nix
@@ -110,12 +110,12 @@ in batsTest {
          skip "${x} is broken (memory leak)"
       fi
 
-      ${bagel}/bin/bagel -np $TEST_NUM_CPUS ${bagel}/share/tests/${x} > ${x}.out
+      mpirun -np $TEST_NUM_CPUS ${bagel}/bin/BAGEL ${bagel}/share/tests/${x} > ${x}.out
     }
   '') files) + ''
 
     @test "Run-Bagel" {
-      ${bagel}/bin/bagel -np $TEST_NUM_CPUS ./bagel.inp > bagel.out
+      mpirun -np $TEST_NUM_CPUS ${bagel}/bin/BAGEL ./bagel.inp > bagel.out
     }
   '';
 

--- a/tests/nwchem/default.nix
+++ b/tests/nwchem/default.nix
@@ -13,7 +13,7 @@ batsTest {
 
   testScript = ''
     @test "Run-nwchem" {
-      nwchem $TEST_NUM_CPUS nwchem.inp > nwchem.out
+      mpirun -np $TEST_NUM_CPUS nwchem nwchem.inp > nwchem.out
     }
 
     @test "DFT Optimize" {


### PR DESCRIPTION
Some cleanup MPI wise:
* remove the wrapper scripts from bagel, nwchem
* remove mpi[run|exec] links from cp2k
* use `propgatedBuildInputs` and `propagatedUserEnvPkgs`. That should work with `nix-shell` as well as `nix-env` (although it's a bad idea to use `nix-env`)

@sheepforce 
Putting `mpi` in `propgatedBuildInputs` is sufficient to have `mpi*` in the path with `nix-shell -p <my-mpi-app>` (no `qchem.mpi` required). I think that mostly solves the problem from a practical perspective. `propagatedUserEnvPkgs` seems to be required to do the same for `nix-env -i <my-mpi-app>` (I haven't tested it)? However, this option is more prone to path collision: let's say you install two different apps from very different nixpkgs version, or even using different MPI implementations, then we get a collsion of `mpi*` binaries in the environment.