### PR TITLE
MKL -> OpenBlas wherever possible

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -115,12 +115,11 @@ let
       # Applications
       #
       bagel = callPackage ./pkgs/apps/bagel {
-        blas = self.mkl; # bagel is not stable with openblas
+        inherit optAVX;
         boost = final.boost165;
-        scalapack=null; withScalapack=true;
       };
 
-      bagel-serial = callPackage ./pkgs/apps/bagel { mpi = null; blas = self.mkl; };
+      bagel-serial = callPackage ./pkgs/apps/bagel { mpi = null; };
 
       cefine = self.nullable self.turbomole (callPackage ./pkgs/apps/cefine { });
 
@@ -361,4 +360,3 @@ let
 
 in
   overlay cfg.prefix { }
-

--- a/pkgs/apps/cp2k/default.nix
+++ b/pkgs/apps/cp2k/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, python3, gfortran, mkl
+{ lib, stdenv, fetchFromGitHub, python3, gfortran, blas, lapack
 , fftw, libint2, libvori, libxc, mpi, gsl, scalapack, openssh, makeWrapper
 , libxsmm, spglib, which
 , optAVX ? false
@@ -33,7 +33,8 @@ in stdenv.mkDerivation rec {
     libxsmm
     spglib
     scalapack
-    mkl
+    blas
+    lapack
   ];
 
   propagatedBuildInputs = [ mpi ];
@@ -73,7 +74,7 @@ in stdenv.mkDerivation rec {
                  -I${libxc}/include -I${libxsmm}/include \
                  -I${libint2}/include
     LIBS       = -lfftw3 -lfftw3_threads \
-                 -lscalapack -lmkl_gf_lp64 -lmkl_gnu_thread -lmkl_core \
+                 -lscalapack -lblas -llapack \
                  -lxcf03 -lxc -lxsmmf -lxsmm -lsymspg \
                  -lint2 -lstdc++ -lvori \
                  -lgomp -lpthread -lm \

--- a/pkgs/apps/xtb/default.nix
+++ b/pkgs/apps/xtb/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, lib, gfortran, fetchFromGitHub, cmake, makeWrapper, mkl
-,  turbomole ? null, orca ? null, cefine ? null
+{ stdenv, lib, gfortran, fetchFromGitHub, cmake, makeWrapper, blas, lapack
+, turbomole ? null, orca ? null, cefine ? null
 } :
 
 stdenv.mkDerivation rec {
@@ -19,13 +19,9 @@ stdenv.mkDerivation rec {
     makeWrapper
   ];
 
-  buildInputs = [
-    mkl
-  ];
+  buildInputs = [ blas lapack ];
 
-  hardeningDisable = [
-    "format"
-  ];
+  hardeningDisable = [ "format" ];
 
   postFixup = let
     # programs that XTB might call.
@@ -45,5 +41,6 @@ stdenv.mkDerivation rec {
     homepage = "https://www.chemie.uni-bonn.de/pctc/mulliken-center/grimme/software/xtb";
     license = licenses.lgpl3Only;
     platforms = platforms.linux;
+    maintainers = [ maintainers.sheepforce ];
   };
 }

--- a/tests/bagel/default.nix
+++ b/tests/bagel/default.nix
@@ -38,8 +38,6 @@ let
     "hf_sto3g_relfci_breit.json"
     "hf_sto3g_relfci_coulomb.json"
     "hf_sto3g_relfci_gaunt.json"
-    "hf_svp_b3lyp.json"
-    "hf_svp_b3lyp_opt.json"
     "hf_svp_breit.json"
     "hf_svp_cas_opt.json"
     "hf_svp_cis.json"

--- a/tests/xtb/default.nix
+++ b/tests/xtb/default.nix
@@ -1,15 +1,10 @@
-{ batsTest, xtb } :
+{ batsTest, lib, xtb, orca ? null } :
 
 batsTest rec {
   name = "xtb";
 
-  auxFiles = [
-    ./RuCO_6.xyz
-  ];
-  outFile = [
-    "xtb.out"
-    "xtb_orca.out"
-  ];
+  auxFiles = [ ./RuCO_6.xyz ];
+  outFile = [ "xtb.out" ] ++ lib.lists.optional (orca != null) "xtb_orca.out";
 
   nativeBuildInputs = [ xtb ];
 
@@ -19,6 +14,7 @@ batsTest rec {
       ${xtb}/bin/xtb RuCO_6.xyz --gfn 2 -u 2 --grad > xtb.out
       grep "GRADIENT NORM               0.2506" xtb.out
     }
+  '' + lib.strings.optionalString (orca != null) ''
     @test "XTB-ORCA" {
       ${xtb}/bin/xtb RuCO_6.xyz --orca -u 2 --grad > xtb_orca.out
       grep "gradient norm              0.1158" xtb_orca.out


### PR DESCRIPTION
After #54 has been merged OpenBlas now actually works in more cases. I was able to replace MKL in Bagel, XTB and CP2K without affecting our test cases. For Bagel I've disabled LibXC support. It doesn't find it anymore (no idea why) but I guess as DFT in Bagel is not documented and not part of the public release anyway (and Bagel is also not the program I would choose to do DFT :smile: ), this should be fine.

Maybe good enough for those 3 for #56 ?

One package that I could not migrate is CREST, [as it explicitly calls mkl routines](https://github.com/grimme-lab/crest/blob/594ef26f266ec0366e4340a349351a7c7c2de0c0/src/solve.f#L266). :disappointed: 