### PR TITLE
cp2k: 8.1.0 -> 8.2.0

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -128,7 +128,6 @@ let
       chemps2 = callPackage ./pkgs/apps/chemps2 { };
 
       cp2k = callPackage ./pkgs/apps/cp2k {
-        libxc = self.libxc4;  # patches are are required for libxc5
         inherit optAVX;
       };
 

--- a/pkgs/apps/cp2k/default.nix
+++ b/pkgs/apps/cp2k/default.nix
@@ -5,7 +5,7 @@
 } :
 
 let
-  version = "8.1.0";
+  version = "8.2.0";
 
   cp2kVersion = "psmp";
   arch = "Linux-x86-64-gfortran";
@@ -18,7 +18,7 @@ in stdenv.mkDerivation rec {
     owner = "cp2k";
     repo = "cp2k";
     rev = "v${version}";
-    sha256 = "1qv7gprmm9riz9jj82n0mh2maij137h3ivh94z22bnm75az86jcs";
+    sha256 = "0kykq5p318hxjzd4gzqjwv9gqshbdvbg0gnjbd9bdfjx1r6jkjn3";
     fetchSubmodules = true;
   };
 

--- a/pkgs/lib/libvori/default.nix
+++ b/pkgs/lib/libvori/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec {
   pname = "libvori";
-  version = "201229";
+  version = "210412";
 
   nativeBuildInputs = [ cmake ];
 
   # Original server is misconfigured and messes up the file compression.
   src = fetchurl {
     url = "https://www.cp2k.org/static/downloads/${pname}-${version}.tar.gz";
-    sha256 = "01ncvqikiabwn1w8995q7h48dzazs69bdl5zmqmdxy4l5hlzn2ns";
+    sha256 = "1b4hpwibf3k7gl6n984l3wdi0zyl2fmpz84m9g2di4yhm6p8c61k";
   };
 
   meta = with lib; {
@@ -17,5 +17,6 @@ stdenv.mkDerivation rec {
     homepage = "https://brehm-research.de/libvori.php";
     license = with licenses; [ lgpl3Only ];
     platforms = platforms.unix;
+    maintainers = [ maintainers.sheepforce ];
   };
 }


### PR DESCRIPTION
CP2K 8.2 released basically just now. This is the update and supports libxc 5. (Does anything else use libxc4 or can we drop it now?)