### PR TITLE
VMD Binaries with CUDA support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Configuration options can be set directly via `config.qchem-config` alongside ot
 * `optpath`: Path to packages that reside outside the nix store. This is mainly relevant for Gaussian and Matlab.
 * `licMolpro`: Molpro license token string required to run molpro.
 * `optAVX`: If this variable is set to true (default) some packages will be explicitly compiled with AVX/AVX2 support. Some upstream packages will be overriden to use make use of AVX (see `nixpkgs-opt.nix`).
+* `useCuda`: Uses Cuda features in selected packages.
 
 
 ### Configuation via environment variables
@@ -52,5 +53,4 @@ The overlay will check for environment variables to configure some features:
 * `NIXQC_OPTPATH`
 * `NIXQC_LICMOLPRO`
 * `NIXQC_AVX`: see `optAVX`, setting this to 1 corresponds to `true`.
-
-
+* `NIXQC_CUDA`: see `useCuda`, setting this to 1 corresponds to `true`.

--- a/cfg.nix
+++ b/cfg.nix
@@ -6,6 +6,7 @@
 , licMolpro ? null
 , prefix ? null
 , optAVX ? null
+, useCuda ? null
 } :
 
   let
@@ -42,4 +43,13 @@
     if (getEnv "NIXQC_AVX") != null then
       (if (getEnv "NIXQC_AVX") == "1" then true else false)
      else true else true;
+
+  # Enable CUDA on selected packages
+  useCuda = if useCuda != null
+    then useCuda
+    else if allowEnv
+      then if (getEnv "NIXQC_CUDA") != null
+        then (if (getEnv "NIXQC_CUDA") == "1" then true else false)
+        else false
+      else false;
 }

--- a/default.nix
+++ b/default.nix
@@ -218,7 +218,10 @@ let
 
       turbomole = callPackage ./pkgs/apps/turbomole { };
 
-      vmd = callPackage ./pkgs/apps/vmd { };
+      vmd = if cfg.useCuda
+        then callPackage ./pkgs/apps/vmd/binary.nix { }
+        else callPackage ./pkgs/apps/vmd { }
+      ;
 
       wfoverlap = callPackage ./pkgs/apps/wfoverlap { };
 

--- a/pkgs/apps/vmd/binary.nix
+++ b/pkgs/apps/vmd/binary.nix
@@ -1,0 +1,93 @@
+{ stdenv, lib, requireFile, makeWrapper, writeScriptBin, bash, perl, tcl-8_5, tk-8_5
+, netcdf, libGLU, xorg, fltk, vrpn, flex, bison, libGL_driver, cudatoolkit, autoPatchelfHook
+}:
+assert
+  lib.asserts.assertMsg
+  (stdenv.isLinux && stdenv.isx86_64)
+  "The VMD binaries require an x86_64 linux OS with CUDA support.";
+
+let homepage = "https://www.ks.uiuc.edu/Research/vmd/";
+
+in stdenv.mkDerivation rec {
+  pname = "vmd";
+  version = "1.9.3";
+
+  src = requireFile {
+    url = homepage;
+    name = "vmd-1.9.3.bin.LINUXAMD64-CUDA8-OptiX4-OSPRay111p1.opengl.tar.gz";
+    sha256 = "9427a7acb1c7809525f70f635bceeb7eff8e7574e7e3565d6f71f3d6ce405a71";
+  };
+
+  nativeBuildInputs = [
+    perl
+    makeWrapper
+    autoPatchelfHook
+  ];
+
+  buildInputs = [
+    libGLU
+    xorg.libX11
+    xorg.libXinerama
+    xorg.libXi
+    tcl-8_5
+    tk-8_5
+    netcdf
+    fltk
+    vrpn
+    flex
+    bison
+    libGL_driver
+    cudatoolkit.out
+    cudatoolkit.lib
+    # nvidia_x11
+  ];
+
+  postPatch = ''
+    substituteInPlace ./configure \
+      --replace '/usr/local' "$out" \
+      --replace '-ll' '-lfl'
+
+    patchShebangs ./configure
+  '';
+
+  sourceRoot = "vmd-${version}";
+
+  # non-standard configure script
+  configurePhase = ''
+    ./configure
+  '';
+
+  dontBuild = true;
+
+  preInstall = ''
+    cd src
+  '';
+
+  postInstall = ''
+    # Needs libcuda.so.1 but only finds libcuda.so
+    ln -s ${cudatoolkit}/targets/x86_64-linux/lib/stubs/libcuda.so $out/lib/libcuda.so.1
+
+    # Makes tachyon available
+    ln -s $out/lib/vmd/{stride,surf,tachyon}_LINUXAMD64 $out/bin/.
+  '';
+
+  # libnvcuvid.so depends on the linuxPackages.nvidia_x11.
+  # This might be overriden in configuration.nix and should be detected at runtime at
+  # /var/run/opengl-driver/lib
+  autoPatchelfIgnoreMissingDeps = true;
+
+  postFixup = ''
+    wrapProgram $out/bin/vmd \
+      --set "LC_ALL" "C"
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    inherit homepage;
+    description = "Molecular dynamics visualisation program";
+    license = licenses.unfree;
+    maintainers = [ maintainers.sheepforce ];
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
Adds the distributed prebuilt VMD binaries. They have SSE, AVX and CUDA enabled and offer additional plugins and Tachyon functionality. A flag has been introduced to enable CUDA for the overlay, similar to `optAVX`. In principle we could also use this to enable CUDA in e.g. CP2K, GPAW, Octopus and Gaussian (although from my experience with CUDA besides VMD this is usually not worth the effort).
While VMD and the missing plugins now run (also in memory ray-tracing), the Nvidia OSPrayRendering does not. It simply crashes with an `Illegal Instruction` error. I've run this version of VMD on my machine already under OpenSuse, where it worked, so this is definitely not a hardware issue. I suspect the issue to be somewhere in the Nvidia libraries, but I am not too familiar with the internal of NixOS graphics stack.