### PR TITLE
[21.05] treewide: remove sheepfore as maintainer

### DIFF
--- a/pkgs/apps/i-pi/default.nix
+++ b/pkgs/apps/i-pi/default.nix
@@ -36,6 +36,6 @@ buildPythonPackage rec {
     license = licenses.gpl3Only;
     homepage = "http://ipi-code.org/";
     platforms = platforms.linux;
-    maintainers = [ maintainers.sheepforce ];
+    maintainers = [  ];
   };
 }

--- a/pkgs/apps/packmol/default.nix
+++ b/pkgs/apps/packmol/default.nix
@@ -29,6 +29,6 @@ stdenv.mkDerivation rec {
     homepage = "http://m3g.iqm.unicamp.br/packmol/home.shtml";
     license = licenses.mit;
     platforms = platforms.linux;
-    maintainers = [ maintainers.sheepforce ];
+    maintainers = [  ];
   };
 }

--- a/pkgs/apps/vmd/binary.nix
+++ b/pkgs/apps/vmd/binary.nix
@@ -87,7 +87,7 @@ in stdenv.mkDerivation rec {
     inherit homepage;
     description = "Molecular dynamics visualisation program";
     license = licenses.unfree;
-    maintainers = [ maintainers.sheepforce ];
+    maintainers = [  ];
     platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/apps/xtb/default.nix
+++ b/pkgs/apps/xtb/default.nix
@@ -41,6 +41,6 @@ stdenv.mkDerivation rec {
     homepage = "https://www.chemie.uni-bonn.de/pctc/mulliken-center/grimme/software/xtb";
     license = licenses.lgpl3Only;
     platforms = platforms.linux;
-    maintainers = [ maintainers.sheepforce ];
+    maintainers = [  ];
   };
 }

--- a/pkgs/lib/libvori/default.nix
+++ b/pkgs/lib/libvori/default.nix
@@ -17,6 +17,6 @@ stdenv.mkDerivation rec {
     homepage = "https://brehm-research.de/libvori.php";
     license = with licenses; [ lgpl3Only ];
     platforms = platforms.unix;
-    maintainers = [ maintainers.sheepforce ];
+    maintainers = [  ];
   };
 }


### PR DESCRIPTION
This change has not made into the 21.05 release (this does not affect the master branches). Patch to clear evaluations errors on Hydra.