### PR TITLE
meep: init at 1.18.0

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -243,6 +243,8 @@ let
       # Libraries
       #
 
+      libctl = callPackage ./pkgs/lib/libctl {};
+
       libefp = callPackage ./pkgs/lib/libefp {};
 
       libint1 = callPackage ./pkgs/lib/libint/1.nix { };

--- a/default.nix
+++ b/default.nix
@@ -247,6 +247,8 @@ let
 
       libefp = callPackage ./pkgs/lib/libefp {};
 
+      libGDSII = callPackage ./pkgs/lib/libGDSII {};
+
       libint1 = callPackage ./pkgs/lib/libint/1.nix { };
 
       libint2 = callPackage ./pkgs/lib/libint { inherit optAVX; };

--- a/default.nix
+++ b/default.nix
@@ -149,6 +149,8 @@ let
 
       gpaw = super.python3.pkgs.toPythonApplication self.python3.pkgs.gpaw;
 
+      harminv = callPackage ./pkgs/apps/harminv { };
+
       nwchem = callPackage ./pkgs/apps/nwchem {
         blas = self.blas-i8;
         lapack = self.lapack-i8;

--- a/default.nix
+++ b/default.nix
@@ -158,6 +158,8 @@ let
 
       mctdh = callPackage ./pkgs/apps/mctdh { };
 
+      meep = super.python3.pkgs.toPythonApplication self.python3.pkgs.meep;
+
       mesa-qc = callPackage ./pkgs/apps/mesa {
         gfortran = final.gfortran6;
       };

--- a/pkgs/apps/harminv/default.nix
+++ b/pkgs/apps/harminv/default.nix
@@ -1,0 +1,25 @@
+{ lib, stdenv, fetchurl, autoreconfHook, gfortran, blas, lapack } :
+
+stdenv.mkDerivation rec {
+  pname = "harminv";
+  version = "1.4.1";
+
+  src = fetchurl {
+    url = "https://github.com/NanoComp/${pname}/releases/download/v${version}/${pname}-${version}.tar.gz";
+    sha256 = "0w1n4d249vlpda0hi6z1v13qp21vlbp3ykn0m8qg4rd5132j7fg1";
+  };
+
+  nativeBuildInputs = [ gfortran ];
+
+  buildInputs = [ blas lapack ];
+
+  configureFlags = [ "--enable-shared" ];
+
+  meta = with lib; {
+    description = "Harmonic inversion algorithm of Mandelshtam: decompose signal into sum of decaying sinusoids";
+    homepage = "https://github.com/NanoComp/harminv";
+    license = with licenses; [ gpl2Only ];
+    maintainers = [ maintainers.sheepforce ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/apps/meep/default.nix
+++ b/pkgs/apps/meep/default.nix
@@ -1,0 +1,103 @@
+{ stdenv, lib, buildPythonPackage, fetchFromGitHub, autoreconfHook, pkg-config
+, gfortran, mpi, blas, lapack, fftw, hdf5-full, swig, gsl, harminv, libctl
+, libGDSII, openssh, guile
+# Python
+, python, numpy, scipy, matplotlib, h5py, cython, autograd, mpi4py
+} :
+
+buildPythonPackage rec {
+  pname = "meep";
+  version = "1.18.0";
+
+  src = fetchFromGitHub {
+    owner = "NanoComp";
+    repo = pname;
+    rev = "v${version}";
+    sha256= "08l4mczkh08dp90c4dlnyx6lsg093li0xqnnbh7q8k363cr8lx81";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    gfortran
+    pkg-config
+    swig
+    mpi
+  ];
+
+  buildInputs = [
+    gsl
+    blas
+    lapack
+    fftw
+    hdf5-full
+    harminv
+    libctl
+    libGDSII
+    guile
+    gsl
+  ];
+
+  propagatedBuildInputs = [
+    mpi
+    numpy
+    scipy
+    matplotlib
+    h5py
+    cython
+    autograd
+    mpi4py
+  ];
+
+  propagatedUserEnvPkgs = [ mpi ];
+
+  dontUseSetuptoolsBuild = true;
+  dontUsePipInstall = true;
+  dontUseSetuptoolsCheck = true;
+
+  HDF5_MPI = "ON";
+  PYTHON = "${python}/bin/${python.executable}";
+
+  enableParallelBuilding = true;
+
+  configureFlags = [
+    "--without-libctl"
+    "--enable-shared"
+    "--with-mpi"
+    "--with-openmp"
+    "--enable-maintainer-mode"
+  ];
+
+  passthru = { inherit mpi; };
+
+  checkInputs = [ openssh ];
+  doCheck = true;
+  checkPhase = ''
+    export PYTHONPATH="$out/lib/${python.libPrefix}/site-packages:$PYTHONPATH"
+    python3 << EOF
+    import meep as mp
+    cell = mp.Vector3(16,8,0)
+    geometry = [mp.Block(mp.Vector3(mp.inf,1,mp.inf),
+                     center=mp.Vector3(),
+                     material=mp.Medium(epsilon=12))]
+    sources = [mp.Source(mp.ContinuousSource(frequency=0.15),
+                     component=mp.Ez,
+                     center=mp.Vector3(-7,0))]
+    pml_layers = [mp.PML(1.0)]
+    resolution = 10
+    sim = mp.Simulation(cell_size=cell,
+                    boundary_layers=pml_layers,
+                    geometry=geometry,
+                    sources=sources,
+                    resolution=resolution)
+    sim.run(until=200)
+    EOF
+  '';
+
+  meta = with lib; {
+    description = "Free finite-difference time-domain (FDTD) software for electromagnetic simulations";
+    homepage = "https://meep.readthedocs.io/en/latest/";
+    license = licenses.gpl2Only;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.sheepforce ];
+  };
+}

--- a/pkgs/lib/libGDSII/default.nix
+++ b/pkgs/lib/libGDSII/default.nix
@@ -1,0 +1,29 @@
+{ lib, stdenv, fetchFromGitHub, autoreconfHook } :
+
+stdenv.mkDerivation rec {
+  pname = "libGDSII";
+  version = "0.21";
+
+  src = fetchFromGitHub {
+    owner = "HomerReid";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0vgxvm04bqaqcgh5h2ar622rscrqym80wi1pfh0xfymxbvp2sw8i";
+  };
+
+  # File is missing in the repo but automake requires it.
+  postPatch = ''
+    touch ChangeLog
+  '';
+
+  nativeBuildInputs = [ autoreconfHook ];
+
+
+  meta = with lib; {
+    description = "Library and command-line utility for reading GDSII geometry files";
+    homepage = "https://github.com/HomerReid/libGDSII";
+    license = with licenses; [ gpl2Only ];
+    maintainers = [ maintainers.sheepforce ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/lib/libctl/default.nix
+++ b/pkgs/lib/libctl/default.nix
@@ -1,0 +1,32 @@
+{ lib, stdenv, fetchFromGitHub, autoreconfHook, gfortran, guile, pkg-config
+} :
+
+stdenv.mkDerivation rec {
+  pname = "libctl";
+  version = "4.5.0";
+
+  src = fetchFromGitHub {
+    owner = "NanoComp";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "03753gk0m2m16y2p6f9fv7l3sr9kspdfzyiv1q6830ky2hx7z5nx";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    gfortran
+    pkg-config
+  ];
+
+  buildInputs = [ guile ];
+
+  configureFlags = [ "--enable-shared" ];
+
+  meta = with lib; {
+    description = "Guile-based library implementing flexible control files for scientific simulations";
+    homepage = "https://github.com/NanoComp/libctl";
+    license = with licenses; [ gpl2Only ];
+    maintainers = [ maintainers.sheepforce ];
+    platforms = platforms.linux;
+  };
+}

--- a/pythonPackages.nix
+++ b/pythonPackages.nix
@@ -10,6 +10,7 @@ let
   lib = selfPkgs.pkgs.lib;
 
   overlay = {
+
     pychemps2 = callPackage ./pkgs/apps/chemps2/PyChemMPS2.nix { };
 
   } // lib.optionalAttrs super.isPy3k {
@@ -22,6 +23,8 @@ let
     gau2grid = callPackage ./pkgs/apps/gau2grid { };
     gau2grid-1_3_1 = callPackage ./pkgs/apps/gau2grid { version = "1.3.1"; sha256 = "0zkfil7cxjip79wqvhljk1ifjq0cwxzx6wlxgp63b6wbagma0i12"; };
     gau2grid-2_0_4 = callPackage ./pkgs/apps/gau2grid { version = "2.0.4"; sha256 = "0qypq8iax0n6yfi4223zya468v24b60nr0x43ypmsafj0104zqa6"; };
+
+    meep = callPackage ./pkgs/apps/meep { };
 
     pylibefp = callPackage ./pkgs/lib/pylibefp { };
 


### PR DESCRIPTION
This adds the meep package for electromagnetics simulations as requested by my colleague @FabianGD. The Scheme interface is disabled for now, as meep somehow does not find `libctl` correctly. The python interface should work nonetheless.

@FabianGD please have a look if it behaves as intended :slightly_smiling_face: 