### PR TITLE
openmm: init at 7.5.1

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -176,6 +176,8 @@ let
 
       multiwfn = callPackage ./pkgs/apps/multiwfn { };
 
+      openmm = super.python3.pkgs.toPythonApplication self.python3.pkgs.openmm;
+
       orca = callPackage ./pkgs/apps/orca { };
 
       osu-benchmark = callPackage ./pkgs/apps/osu-benchmark {
@@ -238,8 +240,8 @@ let
       };
 
       ### Python packages
-      python3 = super.python3.override { packageOverrides=pythonOverrides self super; };
-      python2 = super.python2.override { packageOverrides=pythonOverrides self super; };
+      python3 = super.python3.override { packageOverrides=pythonOverrides cfg self super; };
+      python2 = super.python2.override { packageOverrides=pythonOverrides cfg self super; };
 
       #
       # Libraries

--- a/pkgs/apps/openmm/default.nix
+++ b/pkgs/apps/openmm/default.nix
@@ -1,0 +1,86 @@
+{ buildPythonPackage, lib, fetchFromGitHub, cmake, clang, gfortran, fftwSinglePrec
+, doxygen, ocl-icd, opencl-headers, swig, python, cython, numpy
+, cudatoolkit ? cudatoolkit
+} :
+
+buildPythonPackage rec {
+  pname = "openmm";
+  version = "7.5.1";
+
+  src = fetchFromGitHub {
+    owner = "openmm";
+    repo = pname;
+    rev = version;
+    sha256= "0klxb8apwf6m92jjndsnjdq8wp8xj3717y5z16h1d0b7bxp7jjxx";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    gfortran
+    swig
+    cython
+    doxygen
+  ];
+
+  buildInputs = [
+    fftwSinglePrec
+    ocl-icd
+    opencl-headers
+  ] ++ lib.lists.optional (cudatoolkit != null) cudatoolkit
+  ;
+
+  propagatedBuildInputs = [
+    python
+    numpy
+  ];
+
+  dontUseSetuptoolsBuild = true;
+  dontUsePipInstall = true;
+  dontUseSetuptoolsCheck = true;
+
+  cmakeFlags = [
+    "-DCMAKE_C_COMPILER=${clang}/bin/clang"
+    "-DCMAKE_CXX_COMPILER=${clang}/bin/clang++"
+    "-DBUILD_TESTING=ON"
+    "-DOPENMM_BUILD_AMOEBA_PLUGIN=ON"
+    "-DOPENMM_BUILD_CPU_LIB=ON"
+    "-DOPENMM_BUILD_C_AND_FORTRAN_WRAPPERS=ON"
+    "-DOPENMM_BUILD_DRUDE_PLUGIN=ON"
+    "-DOPENMM_BUILD_PME_PLUGIN=ON"
+    "-DOPENMM_BUILD_PYTHON_WRAPPERS=ON"
+    "-DOPENMM_BUILD_RPMD_PLUGIN=ON"
+    "-DOPENMM_BUILD_SHARED_LIB=ON"
+    "-DOPENMM_BUILD_AMOEBA_OPENCL_LIB=ON"
+    "-DOPENMM_BUILD_OPENCL_LIB=ON"
+    "-DOPENMM_BUILD_DRUDE_OPENCL_LIB=ON"
+    "-DOPENMM_BUILD_RPMD_OPENCL_LIB=ON"
+  ] ++ lib.lists.optionals (cudatoolkit != null) [
+    "-DCUDA_SDK_ROOT_DIR=${cudatoolkit}"
+    "-DOPENMM_BUILD_AMOEBA_CUDA_LIB=ON"
+    "-DOPENMM_BUILD_CUDA_LIB=ON"
+    "-DOPENMM_BUILD_DRUDE_CUDA_LIB=ON"
+    "-DOPENMM_BUILD_RPMD_CUDA_LIB=ON"
+    "-DCMAKE_LIBRARY_PATH=${cudatoolkit}/lib64/stubs"
+  ];
+
+  enableParallelBuilding = true;
+
+  doCheck = true;
+
+  # "make PythonInstall" wants to install into the store-path of the python executable.
+  # Therefore, execute setup.py manually and choose the appropriate prefix.
+  postInstall = ''
+    cd python
+    export OPENMM_INCLUDE_PATH=$out/include
+    export OPENMM_LIB_PATH=$out/lib
+    python setup.py build && python setup.py install --prefix=$out
+  '';
+
+  meta = with lib; {
+    description = "Toolkit for molecular simulation using high performance GPU code";
+    homepage = "https://openmm.org/";
+    license = with licenses; [ gpl3Plus lgpl3Plus mit ];
+    platforms = platforms.linux;
+    maintainers = [ maintainers.sheepforce ];
+  };
+}

--- a/pythonPackages.nix
+++ b/pythonPackages.nix
@@ -1,4 +1,4 @@
-subset: selfPkgs: superPkgs: self: super:
+subset: cfg: selfPkgs: superPkgs: self: super:
 
 let
   callPackage = lib.callPackageWith (
@@ -25,6 +25,10 @@ let
     gau2grid-2_0_4 = callPackage ./pkgs/apps/gau2grid { version = "2.0.4"; sha256 = "0qypq8iax0n6yfi4223zya468v24b60nr0x43ypmsafj0104zqa6"; };
 
     meep = callPackage ./pkgs/apps/meep { };
+
+    openmm = callPackage ./pkgs/apps/openmm {
+      cudatoolkit = if cfg.useCuda then superPkgs.cudaPackages.cudatoolkit_11 else null;
+    };
 
     pylibefp = callPackage ./pkgs/lib/pylibefp { };
 


### PR DESCRIPTION
OpenMM with optional CUDA and OpenCL support. Python, C++ and Fortran bindings enabled. The Nixpkgs manual suggests the `toPythonModule` function in the manual. I couldn't get this to work here directly with OpenMM, as the Python part is not optional. Therefore, I've put it again under python and build it as a python package.

cc @eljost