### PR TITLE
gmultiwfn: init at 3.4.1-0

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -176,6 +176,8 @@ let
 
       multiwfn = callPackage ./pkgs/apps/multiwfn { };
 
+      gmultiwfn = callPackage ./pkgs/apps/gmultiwfn { };
+
       openmm = super.python3.pkgs.toPythonApplication self.python3.pkgs.openmm;
 
       orca = callPackage ./pkgs/apps/orca { };

--- a/pkgs/apps/gmultiwfn/default.nix
+++ b/pkgs/apps/gmultiwfn/default.nix
@@ -1,0 +1,25 @@
+{ lib, stdenv, fetchFromGitHub, gfortran, blas, lapack, autoreconfHook } :
+
+stdenv.mkDerivation rec {
+  pname = "gMultiwfn";
+  version = "3.4.1-0";
+
+  src = fetchFromGitHub {
+    owner = "stecue";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1y43lhk5qrsygl6hf7bk59nskvxd5xb6k7d30mclaz5gqb0lp4hy";
+  };
+
+  nativeBuildInputs = [ gfortran autoreconfHook ];
+
+  buildInputs = [ blas lapack ];
+
+  meta = with lib; {
+    description = "gfortran port of Multiwfn";
+    homepage = "https://github.com/stecue/gMultiwfn";
+    license = with licenses; [ gpl2Only ];
+    maintainers = [ maintainers.sheepforce ];
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
Adding gMultiwfn attribute, as standard Multiwfn encounters issues when dealing with large wave functions. cc @sheepforce 