### PR TITLE
gpaw: GPAW_SETUP_PATH and 21.1.0 -> 21.6.0

### DIFF
--- a/pkgs/apps/gpaw/SetupPath.patch
+++ b/pkgs/apps/gpaw/SetupPath.patch
@@ -1,0 +1,18 @@
+diff --git a/gpaw/__init__.py b/gpaw/__init__.py
+index b5c029e13..518c16b13 100644
+--- a/gpaw/__init__.py
++++ b/gpaw/__init__.py
+@@ -201,12 +201,7 @@ def initialize_data_paths():
+     try:
+         setup_paths[:0] = os.environ['GPAW_SETUP_PATH'].split(os.pathsep)
+     except KeyError:
+-        if len(setup_paths) == 0:
+-            if os.pathsep == ';':
+-                setup_paths[:] = [r'C:\gpaw-setups']
+-            else:
+-                setup_paths[:] = ['/usr/local/share/gpaw-setups',
+-                                  '/usr/share/gpaw-setups']
++        setup_paths[:0] = ["@gpawSetupPath@"]
+ 
+ 
+ read_rc_file()


### PR DESCRIPTION
GPAW always requires the `GPAW_SETUP_PATH` variable, similar to how Sharc requires `$SHARC`. This uses the same mechanism using `setupHooks` to make sure, that not only the `gpaw` executable (as in the previous version) sees this variable, but also the Python interface works without manual intervention.