### PR TITLE
openblas: remove AVX512 workaround

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -21,14 +21,6 @@ let
     pythonOverrides = (import ./pythonPackages.nix) subset;
 
   in {
-    # FIXME: workaround, remove when upstream openblas is fixed
-    # see https://github.com/markuskowa/NixOS-QChem/issues/52
-    # This cause a mass re-build
-    # openblas known broken versions: 0.3.13
-    openblas = super.openblas.overrideAttrs (x: {
-      makeFlags = x.makeFlags ++ [ "NO_AVX512=1" ];
-    });
-
     "${subset}" = {
       # For consistency: every package that is in nixpgs-opt.nix
       # + extra builds that should be exposed


### PR DESCRIPTION
Is now fixed upstream (`nixpkgs-unstable`).
Back port to 21.05 when https://github.com/NixOS/nixpkgs/pull/128074 is merged.

CC @sheepforce 