### PR TITLE
dirac: init at 21.0

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -130,9 +130,13 @@ let
 
       dalton = callPackage ./pkgs/apps/dalton { };
 
-      dkh = callPackage ./pkgs/apps/dkh { };
-
       dftd3 = callPackage ./pkgs/apps/dft-d3 { };
+
+      dirac = callPackage ./pkgs/apps/dirac rec {
+        exatensor = self.exatensor;
+      };
+
+      dkh = callPackage ./pkgs/apps/dkh { };
 
       ergoscf = callPackage ./pkgs/apps/ergoscf { };
 

--- a/default.nix
+++ b/default.nix
@@ -136,6 +136,10 @@ let
 
       ergoscf = callPackage ./pkgs/apps/ergoscf { };
 
+      exatensor = callPackage ./pkgs/apps/exatensor rec {
+        mpi = super.mpi.override { gfortran = super.gfortran8; };
+      };
+
       gaussview = callPackage ./pkgs/apps/gaussview { };
 
       gdma = callPackage ./pkgs/apps/gdma { };

--- a/pkgs/apps/dirac/0001-exatensor-cmake.patch
+++ b/pkgs/apps/dirac/0001-exatensor-cmake.patch
@@ -1,0 +1,192 @@
+diff --git a/cmake/custom/exatensor.cmake b/cmake/custom/exatensor.cmake
+index d203dff..40ca09e 100644
+--- a/cmake/custom/exatensor.cmake
++++ b/cmake/custom/exatensor.cmake
+@@ -1,140 +1,44 @@
++# Patched CMAKE file that does not download any exatensor.
++
+ #Check whether ExaTensor can be used
+-if(ENABLE_EXATENSOR)
+-   if(NOT ENABLE_MPI)
+-       message(STATUS "Using only the TALSH (serial) component of the ExaTensor library")
+-       set(EXATENSOR_TALSH EXA_TALSH_ONLY=YES)
+-       # The following weird construction is needed because these cmake variables are otherwise not active inside the environment and make that is called below
+-       set(TALSH_COMPILERS "CMAKE_Fortran_COMPILER=${CMAKE_Fortran_COMPILER} CMAKE_C_COMPILER=${CMAKE_C_COMPILER} CMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}")
+-   else()
+-       if (NOT (${MPI_Fortran_COMPILER} MATCHES "mpif90" OR ${MPI_Fortran_COMPILER} MATCHES "mpifort"))
+-          message(STATUS "This MPI compiler is not supported by ExaTENSOR, ExaCorr is switched off")
+-          set(ENABLE_EXATENSOR OFF)
+-       endif()
+-   endif()
+-   if(ENABLE_64BIT_INTEGERS)
+-       message(STATUS "ExaTensor library can not work with 64 bit integers, switched off")
+-       set(ENABLE_EXATENSOR OFF)
+-   endif()
++set(ENABLE_EXATENSOR ENABLED)
++
++# ExternalProject_Add seems required as later in the build process,
++# DIRAC includes exatensor via the CMAKE dependency system. It's not 100%
++# clear to me, so I'll just have that as a dummy here.
++ExternalProject_Add(exatensor
++    PREFIX exatensor-tmp
++    INSTALL_DIR @exatensor@
++    STAMP_DIR exatensor-tmp
++    SOURCE_DIR exatensor-tmp/src
++    CONFIGURE_COMMAND true
++    BUILD_COMMAND true
++    INSTALL_COMMAND true
++)
++
++set(EXTERNAL_LIBS ${EXTERNAL_LIBS} @exatensor@/lib/libtalsh.so)
++set(EXTERNAL_LIBS ${EXTERNAL_LIBS} @exatensor@/lib/libexatensor.so)
++
++include_directories(@exatensor@/include)
++
++# Add also the tests (weird to do this here, but this whole test set up needs an overhaul).
++dirac_test(exacorr_talsh_debug "cc;talsh;short" "")
++dirac_test(exacorr_talsh_standalone "cc;talsh;short" "")
++dirac_test(exacorr_talsh_lambda "cc;talsh" "")
++dirac_test(exacorr_talsh_fock "cc;talsh" "")
++dirac_test(exacorr_talsh_open "cc;talsh;short" "")
++dirac_test(exacorr_talsh_cc2 "cc;talsh" "")
++dirac_test(exacorr_talsh_spinfree "cc;talsh" "")
++dirac_test(exacorr_talsh_respect "cc;talsh;respect" "")
++dirac_test(exacorr_talsh_memory "cc;talsh;short" "")
++if (ENABLE_MPI AND NOT EXATENSOR_TALSH)
++    dirac_test(exacorr_exatensor_debug "cc;exatensor" "")
++    dirac_test(exacorr_exatensor_fock "cc;exatensor" "")
++    dirac_test(exacorr_exatensor_open "cc;exatensor" "")
++    dirac_test(exacorr_exatensor_lambda "cc;exatensor" "")
++    dirac_test(exacorr_exatensor_cc2 "cc;exatensor" "")
++    dirac_test(exacorr_exatensor_memory "cc;exatensor;short" "")
+ endif()
+-
+-if(ENABLE_EXATENSOR)
+-
+-    # Provide information about the location of the repository and the specific version (HASH) that should be used. 
+-    # This is configurable to make it possible to configure on machines
+-    # on which the repository resides locally but where network cannot be accessed
+-    # in which case EXATENSOR_GIT_REPO_LOCATION can be set to point to a path on the hard disk
+-    # ./setup --cmake-options="-DEXATENSOR_GIT_REPO_LOCATION='/path/to/exatensor/'"
+-    set (EXATENSOR_GIT_REPO_LOCATION "https://gitlab.com/DmitryLyakh/ExaTensor.git" CACHE STRING "ExaTENSOR Git repository location")
+-    set (EXATENSOR_GIT_HASH d304c03b7289525f250245ece1b4a13a5973fef4 CACHE STRING "ExaTENSOR Git repository hash in use")
+-    set (EXATENSOR_INSTALL_DIR ${PROJECT_BINARY_DIR}/exatensor/src/exatensor/lib)
+-
+-    # The build of ExaTensor is controlled by environment variables, set these using information provided by cmake.
+-
+-    # The supported operating systems for ExaTensor are Linux(default) and MacOSX
+-    if (CMAKE_HOST_APPLE) 
+-       set (EXATENSOR_OS EXA_OS=NO_LINUX)
+-    else()
+-       set (EXATENSOR_OS EXA_OS=LINUX)
+-    endif()
+-
+-    # Check whether we can use GPUs (may need to be more precise as to minimum requirements)
+-    find_package(CUDAToolkit QUIET) 
+-    if (CUDAToolkit_FOUND) 
+-       set (EXATENSOR_GPUENV GPU_CUDA=CUDA)
+-    else()
+-       set (EXATENSOR_GPUENV GPU_CUDA=NOCUDA)
+-    endif()
+-    
+-    # Find out which compiler family we are using (this can be tricky, tweak after the configure step if necessary)
+-    if (CMAKE_Fortran_COMPILER_ID MATCHES GNU) 
+-       set (EXATENSOR_TOOLKIT TOOLKIT=GNU)
+-       if (   "${CMAKE_Fortran_COMPILER_VERSION}" VERSION_LESS "8"
+-           OR "${CMAKE_Fortran_COMPILER_VERSION}" VERSION_EQUAL "9"
+-           OR "${CMAKE_Fortran_COMPILER_VERSION}" VERSION_EQUAL "10" )
+-          set(EXATENSOR_TALSH EXA_TALSH_ONLY=YES)
+-       endif()
+-    elseif(CMAKE_Fortran_COMPILER_ID MATCHES Intel)
+-       set (EXATENSOR_TOOLKIT TOOLKIT=INTEL)
+-       if ("${CMAKE_Fortran_COMPILER_VERSION}" VERSION_LESS "18")
+-          set(EXATENSOR_TALSH EXA_TALSH_ONLY=YES)
+-       endif()
+-    elseif(CMAKE_Fortran_COMPILER_ID MATCHES Cray)
+-       set (EXATENSOR_TOOLKIT TOOLKIT=CRAY)
+-    elseif(CMAKE_Fortran_COMPILER_ID MATCHES XL)
+-       set (EXATENSOR_TOOLKIT TOOLKIT=IBM)
+-    elseif(CMAKE_Fortran_COMPILER_ID MATCHES PGI)
+-       set (EXATENSOR_TOOLKIT TOOLKIT=PGI)
+-     else()
+-       set (EXATENSOR_TOOLKIT TOOLKIT=GNU)
+-       if (   "${CMAKE_Fortran_COMPILER_VERSION}" VERSION_LESS "8"
+-           OR "${CMAKE_Fortran_COMPILER_VERSION}" VERSION_EQUAL "9"
+-           OR "${CMAKE_Fortran_COMPILER_VERSION}" VERSION_EQUAL "10" )
+-          set(EXATENSOR_TALSH EXA_TALSH_ONLY=YES)
+-       endif()
+-    endif()
+-
+-    if (EXATENSOR_TALSH) 
+-       add_definitions(-DEXA_TALSH_ONLY)
+-       message(STATUS "Unsupported compiler for parallel version, using only the TALSH (serial) component of the ExaTensor library")
+-       set(TALSH_COMPILERS "CMAKE_Fortran_COMPILER=${CMAKE_Fortran_COMPILER} CMAKE_C_COMPILER=${CMAKE_C_COMPILER} CMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}")
+-    else()
+-    #If the compiler is mpif90 this is mpich, ExaTensor assumes this is located in PATH_MPICH/bin, get that directory
+-       if (${MPI_Fortran_COMPILER} MATCHES "mpif90")
+-          get_filename_component(MPIDIR ${MPI_Fortran_COMPILER} DIRECTORY)
+-          get_filename_component(PATH_MPI ${MPIDIR} DIRECTORY)
+-          set(EXATENSOR_MPIENV "MPILIB=MPICH PATH_MPICH=${PATH_MPI}")
+-       endif()
+-    #If the compiler is mpifort this is openmpi, ExaTensor assumes this is located in PATH_OPENMPI/bin, get that directory
+-       if (${MPI_Fortran_COMPILER} MATCHES "mpifort")
+-          get_filename_component(MPIDIR ${MPI_Fortran_COMPILER} DIRECTORY)
+-          get_filename_component(PATH_MPI ${MPIDIR} DIRECTORY)
+-          set(EXATENSOR_MPIENV "MPILIB=OPENMPI PATH_OPENMPI=${PATH_MPI}")
+-       endif()
+-    endif()
+-
+-    # Collect everything in one string (also including the hardwires ones that need not be changed) and store this in a file (direct passing appears to be impossible within cmake)
+-    set(EXATENSOR_ENV "WRAP=NOWRAP BUILD_TYPE=OPT ${EXATENSOR_TALSH} ${TALSH_COMPILERS} ${EXATENSOR_TOOLKIT} ${EXATENSOR_OS} ${EXATENSOR_GPUENV} ${EXATENSOR_MPIENV}")
+-    message(STATUS "The environment variables used to build ExaTensor are collected in the file ExaTensor_ENV (can be inspected/changed if necessary)")
+-    file(WRITE ${PROJECT_BINARY_DIR}/ExaTensor_ENV ${EXATENSOR_ENV})
+-
+-    ExternalProject_Add(exatensor
+-        PREFIX "${PROJECT_BINARY_DIR}/exatensor"
+-        GIT_REPOSITORY ${EXATENSOR_GIT_REPO_LOCATION}
+-        GIT_TAG ${EXATENSOR_GIT_HASH}
+-        GIT_CONFIG advice.detachedHead=false
+-        CONFIGURE_COMMAND true  # currently no configure command, but this is needed for cmake to function
+-        BUILD_COMMAND cd ${PROJECT_BINARY_DIR}/exatensor/src/exatensor/ && set -a && . ${PROJECT_BINARY_DIR}/ExaTensor_ENV && set +a && make
+-        INSTALL_DIR ${EXATENSOR_INSTALL_DIR}
+-        INSTALL_COMMAND true
+-        )
+-
+-    set(EXTERNAL_LIBS ${EXTERNAL_LIBS} ${EXATENSOR_INSTALL_DIR}/libtalsh.a)
+-    if (ENABLE_MPI AND NOT EXATENSOR_TALSH)
+-       set(EXTERNAL_LIBS ${EXTERNAL_LIBS} ${EXATENSOR_INSTALL_DIR}/libexatensor.a)
+-    endif()
+-    #In case of problems with the build, one may manually add ExaTENSOR dependencies here (BLAS, OpenMP, CUDA, C++):
+-    #set(EXTERNAL_LIBS ${EXTERNAL_LIBS} -L/sw/summit/essl/6.1.0-2/essl/6.1/lib64 -L/sw/summit/xl/16.1.1-5/xlC/16.1.1/lib -L/sw/summit/xl/16.1.1-5/xlf/16.1.1/lib -lessl -lxlf90_r -lxlfmath -L/sw/summit/cuda/10.1.243/lib64 -lcublas -lcudart -lnvToolsExt -lstdc++ -lgomp)
+-
+-    include_directories(${PROJECT_BINARY_DIR}/exatensor/src/exatensor/include)
+-
+-    #Add also the tests (weird to do this here, but this whole test set up needs an overhaul).
+-    dirac_test(exacorr_talsh_debug "cc;talsh;short" "")
+-    dirac_test(exacorr_talsh_standalone "cc;talsh;short" "")
+-    dirac_test(exacorr_talsh_lambda "cc;talsh" "")
+-    dirac_test(exacorr_talsh_fock "cc;talsh" "")
+-    dirac_test(exacorr_talsh_open "cc;talsh;short" "")
+-    dirac_test(exacorr_talsh_cc2 "cc;talsh" "")
+-    dirac_test(exacorr_talsh_spinfree "cc;talsh" "")
+-    dirac_test(exacorr_talsh_respect "cc;talsh;respect" "")
+-    dirac_test(exacorr_talsh_memory "cc;talsh;short" "")
+-    if (ENABLE_MPI AND NOT EXATENSOR_TALSH)
+-        dirac_test(exacorr_exatensor_debug "cc;exatensor" "")
+-        dirac_test(exacorr_exatensor_fock "cc;exatensor" "")
+-        dirac_test(exacorr_exatensor_open "cc;exatensor" "")
+-        dirac_test(exacorr_exatensor_lambda "cc;exatensor" "")
+-        dirac_test(exacorr_exatensor_cc2 "cc;exatensor" "")
+-	dirac_test(exacorr_exatensor_memory "cc;exatensor;short" "")
+-    endif()
+ #   disabled some tests waiting for code verification/efficiency improvement
+ #   dirac_test(exacorr_talsh_cholesky "cc;talsh" "")
+ #   dirac_test(exacorr_exatensor_cholesky "cc;exatensor" "")
+@@ -142,7 +46,4 @@ if(ENABLE_EXATENSOR)
+ #   dirac_test(exacorr_exatensor_ao2mo "cc;exatensor" "")
+ #   dirac_test(exacorr_exatensor_spinfree "cc;exatensor" "")
+ 
+-
+-endif()
+-
+ message(STATUS "Enable ExaTENSOR library: ${ENABLE_EXATENSOR}")

--- a/pkgs/apps/dirac/default.nix
+++ b/pkgs/apps/dirac/default.nix
@@ -1,0 +1,129 @@
+{ stdenv, lib, fetchurl, gfortran, cmake, makeWrapper
+, which, openssh, blas, lapack, mpi, boost, exatensor, python3
+} :
+
+assert
+  lib.asserts.assertMsg
+  (!blas.isILP64)
+  "A 32 bit integer implementation of BLAS is required.";
+
+stdenv.mkDerivation rec {
+  pname = "dirac";
+  version = "21.0";
+
+  nativeBuildInputs = [
+    which
+    gfortran
+    cmake
+    python3
+    makeWrapper
+    openssh
+  ];
+
+  # For now, DIRAC is built without the PCMSolver optional dependency.
+  buildInputs = [
+    blas
+    lapack
+    boost
+    exatensor
+  ];
+
+  propagatedBuildInputs = [
+    mpi
+  ];
+
+  src = fetchurl {
+    url = "https://zenodo.org/record/4836496/files/DIRAC-${version}-Source.tar.gz";
+    sha256 = "0vqmin24xqkcp3rvml0dimc4kjmb3m37c3l6bkjy4y6d3xyb41yg";
+  };
+
+  patches = [
+    ./0001-exatensor-cmake.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace ./cmake/custom/exatensor.cmake \
+    --subst-var-by exatensor ${exatensor}
+
+    patchShebangs .
+  '';
+
+  FC = "mpif90";
+  CC = "mpicc";
+  CXX = "mpicxx";
+  MATH_ROOT = blas;
+  ENABLE_EXATENSOR = "ON";
+
+  /*
+  Cmake is required to build but adding it to the buildinputs then ignores the
+  setup script. Therefore i call the script here manually but cmake is invoked
+  by setup.
+  */
+
+  configurePhase = ''
+    ./setup --prefix=$out --mpi
+  '';
+
+  preBuild = ''
+    cd build
+  '';
+
+  # Parallel building of the DIRAC package introduces all kinds of unpredictable
+  # bugs when modules within a single folder depend on each other.
+  # enableParallelBuilding = true;
+
+  hardeningDisable = [ "format" ];
+  doInstallCheck = true;
+
+  /*
+  Make the MPI stuff available to the DIRAC script by hard-coding the MPI path.
+  Moving pam-dirac to pam to conform with the DIRAC manual. Usually there is a
+  weird hack in the install.cmake to install pam into the bin folder.
+
+  The pam script is just a Python script that sets a ton of ENV variables.
+  */
+  postFixup = ''
+    mv $out/bin/pam-dirac $out/bin/pam
+
+    substituteInPlace $out/bin/pam \
+      --replace "find_executable('mpirun')" "'${mpi}/bin/mpirun'"
+  '';
+
+  # This is a small initial calculation to see whether everything works just fine.
+  # http://diracprogram.org/doc/release-21/tutorials/getting_started.html
+  installCheckPhase = ''
+    cat > methanol.xyz << EOF
+      6
+      my first DIRAC calculation # anything can be in this line
+      C       0.000000000000       0.138569980000       0.355570700000
+      O       0.000000000000       0.187935770000      -1.074466460000
+      H       0.882876920000      -0.383123830000       0.697839450000
+      H      -0.882876940000      -0.383123830000       0.697839450000
+      H       0.000000000000       1.145042790000       0.750208830000
+      H       0.000000000000      -0.705300580000      -1.426986340000
+    EOF
+
+    cat > hf.inp <<-EOF
+    **DIRAC
+    .WAVE FUNCTION
+    **WAVE FUNCTION
+    .SCF
+    **MOLECULE
+    *BASIS
+    .DEFAULT
+    cc-pVDZ
+    *END OF INPUT
+    EOF
+
+    $out/bin/pam --mpi=2 --mol=$(pwd)/methanol.xyz --inp=$(pwd)/hf.inp --scratch=$(pwd)
+  '';
+
+  passthru = { inherit mpi; };
+
+  meta = with lib; {
+    description = "The DIRAC program computes molecular properties using relativistic quantum chemical methods.";
+    license = licenses.unfree;
+    homepage = "https://diracprogram.org/";
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/apps/exatensor/default.nix
+++ b/pkgs/apps/exatensor/default.nix
@@ -1,0 +1,51 @@
+{ stdenv, lib, fetchFromGitLab, blas, mpi } :
+
+let
+  version = "2020-07-15";
+
+in stdenv.mkDerivation rec {
+  pname = "exatensor";
+  inherit version;
+
+  src = fetchFromGitLab {
+    owner = "DmitryLyakh";
+    repo = pname;
+    rev = "d304c03b7289525f250245ece1b4a13a5973fef4";
+    sha256 = "0zlqwpdqfycwvys39lvvj94cprhaxmyaxxs1c66f10dazjbafp49";
+  };
+
+  buildInputs = [ blas.passthru.provider ];
+
+  MPILIB = if (mpi.pname == "openmpi") then "OPENMPI"
+    else if (mpi.pname == "mpich") then "MPICH"
+    else throw "Only openmpi and mpich supported by ${pname}.";
+
+  PATH_OPENMPI = mpi;
+  PATH_MPICH = mpi;
+
+  BLASLIB =
+    if (blas.passthru.implementation == "openblas") then "OPENBLAS"
+    else if (blas.passthru.implementation == "mkl") then "MKL"
+    else throw "Only MKL and OPENBLAS supported by ${pname}.";
+
+  PATH_BLAS_OPENBLAS = blas.passthru.provider;
+  PATH_BLAS_MKL = blas.passthru.provider;
+  PATH_BLAS_MKL_DEP = "${blas.passthru.provider}/lib";
+  PATH_BLAS_MKL_INC = "${blas.passthru.provider}/include";
+
+  installPhase = ''
+    mkdir -p $out/lib $out/bin $out/include
+    cp -r ./bin/* $out/bin
+    cp -r ./lib/* $out/lib
+    cp -r ./include/* $out/include
+  '';
+
+  meta = with lib; {
+    description = "ExaTENSOR is a basic numerical tensor algebra library for
+distributed HPC systems equipped with multicore CPU and NVIDIA or AMD GPU.";
+    homepage = https://gitlab.com/DmitryLyakh/ExaTensor;
+    license = licenses.lgpl3Only;
+    platforms = platforms.linux;
+  };
+}
+


### PR DESCRIPTION
This PR adds [DIRAC 21.0](https://diracprogram.org/) and it's dependency [ExaTensor](https://gitlab.com/DmitryLyakh/ExaTensor) to the collection. 

ExaTensor is currently in (more or less) early development so that no version tags exist. DIRAC requires a very specific version so I used the last 6 characters of the git hash as a reference. Is there a better way about that?

Furthermore, DIRAC has the possibility to include PCMSolver (at v1.1.1) to the build. I skip this for now, as fixing it requires even more patching of the CMake build system of DIRAC. What do you think about that?

Best,
Fabi 