### PR TITLE
Allow current Molcas 21.06 in SHARC 2.1

### DIFF
--- a/pkgs/apps/sharc/21.nix
+++ b/pkgs/apps/sharc/21.nix
@@ -46,7 +46,7 @@ in stdenv.mkDerivation {
   '';
 
   binSearchPath = with lib; strings.makeSearchPath "bin" ([ molcas bagel gnuplot ]
-   ++ lists.optional (orca != null) orca
+    ++ lists.optional (orca != null) orca
     ++ lists.optional (gaussian != null) gaussian
     ++ lists.optional (turbomole != null) turbomole
     ++ lists.optional (molpro != null) molpro

--- a/pkgs/apps/sharc/molcas_version.patch
+++ b/pkgs/apps/sharc/molcas_version.patch
@@ -3,11 +3,11 @@ index c49da01..5d61d1f 100755
 --- a/bin/SHARC_MOLCAS.py
 +++ b/bin/SHARC_MOLCAS.py
 @@ -873,7 +873,7 @@ def makermatrix(a,b):
- 
+
  # ======================================================================= #
  def getversion(out,MOLCAS):
 -    allowedrange=[ (18.0,18.999), (8.29999,8.30001) ]
-+    allowedrange=[ (18.0,21.02), (8.29999,8.30001) ]
++    allowedrange=[ (18.0,21.06), (8.29999,8.30001) ]
      # first try to find $MOLCAS/.molcasversion
      molcasversion=os.path.join(MOLCAS,'.molcasversion')
      if os.path.isfile(molcasversion):


### PR DESCRIPTION
We haven't updated the Molcas patch in sharc, which allows to use newer versions. This broke Molcas in SHARC. This should again fix it.