### PR TITLE
Q-Chem: init at 5.{1..4}

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The latest builds for the master branch and stable version are stored on [Cachix
 * Cache URL: https://nix-qchem.cachix.org
 * Public key: nix-qchem.cachix.org-1:ZjRh1PosWRj7qf3eukj4IxjhyXx6ZwJbXvvFk3o3Eos=
 
-If you are allowed to add binary substituters (as trusted user), 
+If you are allowed to add binary substituters (as trusted user),
 you may simply add it with `nix-shell -p cachix --run "cachix use nix-qchem"`.
 
 ## Configuration
@@ -47,6 +47,26 @@ you may simply add it with `nix-shell -p cachix --run "cachix use nix-qchem"`.
 The overlay can be configured either via an attribute set or via environment variables.
 If no attribute set is given the configuration the environment variables are automatically
 considered (impure).
+
+### Special Installation Instructions
+
+#### Q-Chem
+The Q-Chem version `5.{1..4}` are packaged. Download the Linux binaries with all options enabled for your respective version at [https://www.q-chem.com/install/#linux](https://www.q-chem.com/install/#linux).
+Q-Chem is evaluated in two steps to obtain a valid license, after the installer has run.
+
+  1. Build the installer `nix-build -A qchem.q-chem-installer`.
+     This will install Q-Chem into the store and prepare a preliminary `license.data` file, and prepare a script, that helps you to obtain the final `license.data`.
+     The `qchem.q-chem-installer.getLicense` attribute (available as `./result/bin/q-chem_prep_license`) requires the following environment variables
+
+     - `$QCHEM_NODES`: a space-separated list of nodes, for which a Q-Chem license should be obtained. All nodes must be reachable via MPI.
+     - `$QCHEM_MAIL`: the e-mail address associated with the Q-Chem license. The license file will be sent to this address by Q-Chem.
+     - `$QCHEM_ORDNUM:` the order number for Q-Chem.
+
+     After these variables have been set, run `./result/bin/q-chem_prep_license`. You should now have `./license.data`. Send this file via mail to `license@q-chem.com`.
+
+  2. After you have received your license file from `license@q-chem.com`, point `$NIXQC_LICQCHEM` or `licQChem` to this file.
+     The `qchem.q-chem` attribute can be used normally, now; i.e. `nix-build -A qchem.q-chem`.
+
 
 ### Configuration via nixpkgs
 Configuration options can be set directly via `config.qchem-config` alongside other nixpkgs config options.
@@ -56,8 +76,9 @@ Configuration options can be set directly via `config.qchem-config` alongside ot
 * `srcurl`: URL for non-free packages. If set this will override the `requireFile` function of nixpkgs to pull all non-free packages from the specified URL
 * `optpath`: Path to packages that reside outside the nix store. This is mainly relevant for Gaussian and Matlab.
 * `licMolpro`: Molpro license token string required to run molpro.
-* `optArch`: Set gcc compiler flags (mtune and march) to optmize for a specfic architecture. Some upstream packages will be overriden to use make use of AVX (see `nixpkgs-opt.nix`). Note, that this also overrides the stdenv
+* `optArch`: Set gcc compiler flags (`mtune` and `march`) to optimize for a specific architecture. Some upstream packages will be overriden to use make use of AVX (see `nixpkgs-opt.nix`). Note, that this also overrides the stdenv
 * `useCuda`: Uses Cuda features in selected packages.
+* `licQChem`: Path to a Q-Chem license file as obtained via mail.
 
 
 ### Configuation via environment variables
@@ -70,3 +91,4 @@ The overlay will check for environment variables to configure some features:
 * `NIXQC_AVX`: see `optAVX`, setting this to 1 corresponds to `true`.
 * `NIXQC_OPTARCH`
 * `NIXQC_CUDA`: see `useCuda`, setting this to 1 corresponds to `true`.
+* `NIXQC_LICQCHEM`: see `licQChem`

--- a/cfg.nix
+++ b/cfg.nix
@@ -8,6 +8,7 @@
 , optAVX ? null
 , optArch ? null
 , useCuda ? null
+, licQChem ? null
 } :
 
 let
@@ -60,4 +61,7 @@ in {
 
   # Enable CUDA on selected packages
   useCuda = getBoolValue useCuda false "NIXQC_CUDA";
+
+  # QChem license information
+  licQChem = getValue licQChem null "NIXQC_LICQCHEM";
 }

--- a/overlay.nix
+++ b/overlay.nix
@@ -191,6 +191,8 @@ let
 
         pysisyphus = super.python3.pkgs.toPythonApplication self.python3.pkgs.pysisyphus;
 
+        q-chem-installer = callPackage ./pkgs/apps/q-chem/installer.nix { };
+
         qdng = callPackage ./pkgs/apps/qdng {
           stdenv = aggressiveStdenv;
           protobuf = super.protobuf3_11;
@@ -337,6 +339,8 @@ let
         molpro20 = null;
         molpro-ext = null;
 
+        q-chem = null;
+
         # Provide null gaussian attrs in case optpath is not set
         gaussian = null;
       } // lib.optionalAttrs (cfg.licMolpro != null) {
@@ -354,6 +358,10 @@ let
 
         molpro-ext = callPackage ./pkgs/apps/molpro/custom.nix { token = cfg.licMolpro; };
 
+      } // lib.optionalAttrs (cfg.licQChem != null) {
+        q-chem = callPackage ./pkgs/apps/q-chem/default.nix {
+          qchemLicensePath = cfg.licQChem;
+        };
       } // lib.optionalAttrs (cfg.optpath != null) {
         #
         # Quirky packages that need to reside outside the nix store

--- a/pkgs/apps/q-chem/default.nix
+++ b/pkgs/apps/q-chem/default.nix
@@ -1,0 +1,58 @@
+{ stdenv, lib, writeTextFile, q-chem-installer, openssh, makeWrapper
+, qchemLicensePath ? null
+}:
+
+assert
+  lib.asserts.assertMsg
+  (qchemLicensePath != null)
+  "A Q-Chem license is required to run Q-Chem";
+
+let
+  wrapperArgs = [
+    "--set QC $out"
+    "--set QCPLATFORM LINUX_Ix86_64"
+    "--set QCMPI seq"
+    "--set QCRSH ssh"
+    "--set-default QCSCRATCH /tmp"
+    "--set-default QCAUX $out/qcaux"
+    "--prefix PATH : ${openssh}/bin"
+  ];
+in stdenv.mkDerivation {
+  name = "${q-chem-installer.qchemInit.pname}-${q-chem-installer.qchemInit.version}";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  phases = [ "installPhase" ];
+
+  installPhase = ''
+    mkdir -p $out/{bin,exe,qcaux/license}
+
+    BINS=$(find ${q-chem-installer.qchemInit}/bin -type f -executable)
+    BINS_L=$(find ${q-chem-installer.qchemInit}/bin -type l)
+    EXES=$(find ${q-chem-installer.qchemInit}/exe -type f -executable)
+    EXES_L=$(find ${q-chem-installer.qchemInit}/exe -type l)
+
+    # Symlink all files, that are not executables
+    ln -s ${q-chem-installer.qchemInit}/{config,samples,share,version.txt} $out/.
+    ln -s $(find ${q-chem-installer.qchemInit}/qcaux -maxdepth 1 -not -name "license") $out/qcaux/.
+
+    # Install the license file
+    echo '${builtins.readFile qchemLicensePath}' > $out/qcaux/license/qchem.license.dat
+
+    # Make a wrapper around files in bin
+    for i in $BINS; do makeWrapper $i $out/bin/$(basename $i) ${builtins.toString wrapperArgs}; done
+
+    # Same for files in exes
+    for i in $EXES; do makeWrapper $i $out/exe/$(basename $i) ${builtins.toString wrapperArgs}; done
+
+    # Additional loops to preserve symlink structures in bin and exe
+    for l in $BINS_L; do
+      ln -s $out/bin/$(basename $(readlink -f $l)) $out/bin/$(basename $l)
+    done
+    for l in $EXES_L; do
+      ln -s $out/exe/$(basename $(readlink -f $l)) $out/exe/$(basename $l)
+    done
+  '';
+
+  meta = q-chem-installer.qchemInit.meta;
+}

--- a/pkgs/apps/q-chem/installer.nix
+++ b/pkgs/apps/q-chem/installer.nix
@@ -1,0 +1,132 @@
+{ stdenv, lib, requireFile, autoPatchelfHook, tcsh, perl, openssh
+, writeScript, runtimeShell, hostname
+, minorVersion ? 1
+} :
+
+assert
+  lib.asserts.assertMsg
+  (builtins.elem minorVersion [ 1 2 3 4 ])
+  "Unsupported version of Q-Chem";
+
+let
+  url = "https://www.q-chem.com/install/#linux";
+  qchemSrc-5_1 = requireFile {
+    inherit url;
+    name = "qc5${builtins.toString minorVersion}.tar";
+    sha256 = "71b0d7fd4f6b47a090e25267c53fb38f5dbc50a8d159f2e8669ecba8f88f5d96";
+  };
+  qchemSrc-5_2 = requireFile {
+    inherit url;
+    name = "qc5${builtins.toString minorVersion}.tar";
+    sha256 = "cf513b8215369d9e904f7f22bca5f8d43a39b3fd166c2e4ddf5f67965b50a6fa";
+  };
+  qchemSrc-5_3 = requireFile {
+    inherit url;
+    name = "qc5${builtins.toString minorVersion}.tar";
+    sha256 = "5e616542e3bd20ef299fed97ef8f8ab30c3fa264cdc0c8fe900bfa30d975c3d8";
+  };
+  qchemSrc-5_4 = requireFile {
+    inherit url;
+    name = "qc5${builtins.toString minorVersion}.tar";
+    sha256 = "5f62677c17fc62f6da2eb6d3f43efcc9569e5feea9313c870729c562aa3e41a9";
+  };
+
+  # Runs the installer script and prepares valid installation in the store.
+  # License will be missing after the installation, thus this preliminary
+  # version will not work, yet. Use the activation script to obtain a license.
+  qchemInit = stdenv.mkDerivation rec {
+    pname = "Q-Chem";
+    version = "5.${builtins.toString minorVersion}";
+
+    src =
+      if minorVersion == 1 then qchemSrc-5_1
+      else if minorVersion == 2 then qchemSrc-5_2
+      else if minorVersion == 3 then qchemSrc-5_3
+      else if minorVersion == 4 then qchemSrc-5_4
+      else "";
+
+    nativeBuildInputs = [ autoPatchelfHook ];
+    buildInputs = [ stdenv.cc.cc.lib ];
+    runtimeDependencies = buildInputs;
+    propagatedBuildInputs = [ tcsh perl openssh ];
+
+    sourceRoot = if minorVersion == 4 then "qc54_distrib" else ".";
+
+    postPatch = ''
+      patchShebangs ./qcinstall.sh
+    '';
+
+    dontConfigure = true;
+    dontBuild = true;
+
+    # Run the interactive configuration script.
+    # It will prepare a file to be sent to license@q-chem.com,
+    # but the HostIds will be missing, as get_hostid has not been fixed yet.
+    installPhase =
+      let installAnswers = lib.strings.concatStringsSep "\n" ([
+            "$out"                     # Installation directory
+            "1"                        # Flavour to install. 1 -> SMP parallel, > 1 different MPI and CUDA flavours
+            ""                         # Skip a count down
+            "/tmp"                     # Default scratch directory. ignored when finishing the derivation in the second step
+            "2000"                     # Default memory for Q-Chem processes in MiB. ignored when finishing derivation in the second step
+            "n"                        # Don't view license
+            "y"                        # Agree to license
+            ""                         # Skip countdown
+            "3000"                     # Order number, that works for all Q-Chem versions 5.{1..4}
+            "someone@example.com"      # Fake mail adress substituted later. Needs to be a well formed, though
+            "y"                        # Confirm that the answers are "correct". Of course they are not, but the activation script solves this later
+          ] ++ lib.optional (minorVersion >= 2) "1" # Use a license file instead of setting up a separate license server
+          );
+      in ''
+        ./qcinstall.sh << EOF
+        ${installAnswers}
+        EOF
+      '';
+
+    autoPatchelfIgnoreMissingDeps = true;
+    postFixup = ''
+      # Patch shebangs of perl and csh scripts
+      find -name "*.pl" -exec sed -i "s!/usr/bin/perl!${perl}/bin/perl" {} \;
+      find -name "*.csh" -exec sed -i "s!/bin/csh!${tcsh}/bin/tcsh" {} \;
+    '';
+
+    meta = with lib; {
+      description = "General purpose quantum chemistry program with Gaussian basis sets";
+      homepage = "https://q-chem.com/";
+      license = licenses.unfree;
+      platforms = [ "x86_64-linux" ];
+      maintainers = [ maintainers.sheepforce ];
+    };
+  };
+
+  getLicense = writeScript "q-chem_prep-license" ''
+    #! ${runtimeShell}
+    set -e
+
+    if [[ -z "$QCHEM_NODES" || -z "$QCHEM_MAIL" || -z "$QCHEM_ORDNUM" ]]
+      then
+        echo "Set the \$QCHEM_NODES variable to a list of hostnames, which should be part of the Q-Chem license."
+        echo "Set \$QCHEM_MAIL to your mail account, associated with the Q-Chem license."
+        echo "Set \$QCHEM_ORDNUM to your order number for your Q-Chem license."
+        echo "The script will use MPI to obtain the required information from all Nodes."
+      else
+        # Obtain the Q-Chem information on all nodes.
+        # Dials in via ssh and executes the get_hostid command
+        HOSTINFO=$(for N in $QCHEM_NODES; do
+          if [[ "$N" = "$(${hostname}/bin/hostname)" || "$N" == "localhost" || "$N" == "127.0.0.1" ]]
+            then ${qchemInit}/bin/get_hostid
+            else ssh $N ${qchemInit}/bin/get_hostid
+          fi
+        done)
+
+        # Update the license file
+        HEAD=$(head -n -2 ${qchemInit}/license.data)
+        FOOT="#end_sid"
+        printf "$HEAD\n  $HOSTINFO\n  $FOOT" > license.data
+        sed -i "s/someone@example.com/$QCHEM_MAIL/g" license.data
+        sed -i "s/3000/$QCHEM_ORDNUM/g" license.data
+        echo "Send ./license.data to license@q-chem.com"
+    fi
+  '';
+
+in { inherit qchemInit getLicense; }


### PR DESCRIPTION
This is an attempt to add Q-Chem to the overlay. Q-Chem installation is unfortunately very tricky with Nix and I could use some pointers. Q-Chem puts a major obstacle in my way. The license/registration process:

Q-QChem has an interactive installation script, that I attempt to answer in the `installPhase`. This installation script wants to either have network access, to request a license-file on the fly from the Q-Chem servers, or asks for an order number and registered mail address (better). It then figures out, the machines name and hardware (CPU cores and GPUs mainly) and writes a file, that is to be submitted to the Q-Chem mail address manually, which in turn will send a license token file, registering each node on which Q-Chem shall run. This must be put in the Q-Chem installation directory. I have absolutely no good idea how to handle this. The only thing I could come up with is to make a second derivation with the license token in a separate store path and then `symlinkJoin` them later. But this is a very manual approach and I have no idea how to get this reproducible. The license file and its hash changes, of course.