### PR TITLE
Allow for gcc optmization flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Configuration options can be set directly via `config.qchem-config` alongside ot
 * `srcurl`: URL for non-free packages. If set this will override the `requireFile` function of nixpkgs to pull all non-free packages from the specified URL
 * `optpath`: Path to packages that reside outside the nix store. This is mainly relevant for Gaussian and Matlab.
 * `licMolpro`: Molpro license token string required to run molpro.
-* `optAVX`: If this variable is set to true (default) some packages will be explicitly compiled with AVX/AVX2 support. Some upstream packages will be overriden to use make use of AVX (see `nixpkgs-opt.nix`).
+* `optArch`: Set gcc compiler flags (mtune and march) to optmize for a specfic architecture. Some upstream packages will be overriden to use make use of AVX (see `nixpkgs-opt.nix`). Note, that this also overrides the stdenv
 * `useCuda`: Uses Cuda features in selected packages.
 
 
@@ -53,4 +53,5 @@ The overlay will check for environment variables to configure some features:
 * `NIXQC_OPTPATH`
 * `NIXQC_LICMOLPRO`
 * `NIXQC_AVX`: see `optAVX`, setting this to 1 corresponds to `true`.
+* `NIXQC_OPTARCH`
 * `NIXQC_CUDA`: see `useCuda`, setting this to 1 corresponds to `true`.

--- a/cfg.nix
+++ b/cfg.nix
@@ -6,10 +6,11 @@
 , licMolpro ? null
 , prefix ? null
 , optAVX ? null
+, optArch ? null
 , useCuda ? null
 } :
 
-  let
+let
   # getEnv that returns null if var is not set
   getEnv = x:
   let
@@ -31,7 +32,9 @@
       else default
     else default;
 
- in {
+  AVX = getBoolValue optAVX true "NIXQC_AVX";
+
+in {
 
   # Put the package set under prefix
   prefix = getValue prefix "qchem" "NIXQC_PREFIX";
@@ -45,8 +48,15 @@
   # string containing a valid MOLPRO license token
   licMolpro = getValue licMolpro null "NIXQC_LICMOLPRO";
 
-  # turn of AVX optimizations in selected packages
-  optAVX = getBoolValue optAVX true "NIXQC_AVX";
+  # turn on AVX optimizations
+  optAVX = AVX;
+
+  # Optimize for a specific gcc Arch
+  # corresponds to skylake when AVX is requested
+  optArch = let
+    arch = getValue optArch null "NIXQC_OPTARCH";
+  in if arch != null then arch
+      else if AVX then "haswell" else null;
 
   # Enable CUDA on selected packages
   useCuda = getBoolValue useCuda false "NIXQC_CUDA";

--- a/default.nix
+++ b/default.nix
@@ -9,9 +9,6 @@ let
 
   lib = prev.lib;
 
-  optAVX = cfg.optAVX;
-
-
   # Create a stdenv with CPU optimizations
   makeOptStdenv = stdenv: arch: if arch == null then stdenv else
   stdenv.override (old: {
@@ -95,7 +92,6 @@ let
       # Applications
       #
       bagel = callPackage ./pkgs/apps/bagel {
-        inherit optAVX;
         boost = final.boost165;
       };
 

--- a/default.nix
+++ b/default.nix
@@ -11,6 +11,28 @@ let
 
   optAVX = cfg.optAVX;
 
+
+  # Create a stdenv with CPU optimizations
+  makeOptStdenv = stdenv: arch: if arch == null then stdenv else
+  stdenv.override (old: {
+    name = old.name + "-${arch}";
+
+    # Make sure respective CPU features are set
+    hostPlatform = old.hostPlatform //
+       lib.mapAttrs (p: a: a arch) lib.systems.architectures.predicates;
+
+    # Add additional compiler flags
+    extraAttrs = {
+      mkDerivation = args: stdenv.mkDerivation ( args // {
+        NIX_CFLAGS_COMPILE = toString (args.NIX_CFLAGS_COMPILE or "") + " -march=${arch} -mtune=${arch}";
+      });
+    };
+  });
+
+  optStdenv = makeOptStdenv final.stdenv cfg.optArch;
+
+
+
   #
   # Our package set
   #
@@ -20,36 +42,12 @@ let
     callPackage = super.lib.callPackageWith (final // self);
     pythonOverrides = (import ./pythonPackages.nix) subset;
 
+    optUpstream = import ./nixpkgs-opt.nix final prev self optStdenv;
+
   in {
-    "${subset}" = {
-      # For consistency: every package that is in nixpgs-opt.nix
-      # + extra builds that should be exposed
-      inherit (final)
-        cp2k
-        ergoscf
-        fftwSinglePrec
-        hpl
-        hpcg
-        gromacs
-        gromacsMpi
-        gromacsDouble
-        gromacsDoubleMpi
-        i-pi
-        libint
-        mpi
-        mkl
-        molden
-        libxsmm
-        octopus
-        quantum-espresso
-        quantum-espresso-mpi
-        pcmsolver
-        scalapack
-        siesta
-        siesta-mpi;
+    "${subset}" = optUpstream // {
 
       pkgs = final;
-
 
       inherit callPackage;
 
@@ -64,21 +62,6 @@ let
 
       lapack-i8 = if final.lapack.implementation != "amd-libflame" then prev.lapack.override { isILP64 = true; }
         else super.lapack.override { isILP64 = true; lapackProvider = super.openblas; };
-
-      fftw = final.fftw.overrideAttrs ( oldAttrs: {
-        buildInputs = [ final.gfortran ];
-      });
-
-      fftw-mpi = self.fftw.overrideAttrs (oldAttrs: {
-        configureFlags = oldAttrs.configureFlags ++ [
-          "--enable-mpi"
-          "MPICC=${self.mpi}/bin/mpicc"
-          "MPIFC=${self.mpi}/bin/mpif90"
-          "MPIF90=${self.mpi}/bin/mpif90"
-        ];
-
-        propagatedBuildInputs = [ self.mpi ];
-      });
 
       # For molcas and chemps2
       hdf5-full = final.hdf5.override {
@@ -346,9 +329,7 @@ let
       matlab = callPackage ./pkgs/apps/matlab { inherit (cfg) optpath; };
 
     } // extra;
-  } // lib.optionalAttrs optAVX (
-    import ./nixpkgs-opt.nix final super
-    );
+  };
 
 in
   overlay cfg.prefix { }

--- a/nixpkgs-opt.nix
+++ b/nixpkgs-opt.nix
@@ -1,70 +1,83 @@
-self: super:
-{
-  #
-  # Package set with optimized upstream libraries
-  #
+final: prev: self: optStdenv:
 
-  # Compile fftw with full AVX features
-  fftw = super.fftw.overrideAttrs ( oldAttrs: {
-    configureFlags = oldAttrs.configureFlags
-    ++ [
-      "--enable-avx"
-      "--enable-avx2"
-      "--enable-fma"
-      "--enable-avx-128-fma"
-    ];
-    buildInputs = oldAttrs.buildInputs ++ [ self.gfortran ];
-  });
+#
+# Package set with upstream libraries
+# and optimizations of upstream packages
+#
 
-  fftw-mpi = self.fftw.overrideAttrs ( oldAttrs: {
-    buildInputs = oldAttrs.buildInputs ++ [ self.mpi ];
+with final;
+let
+  hp = optStdenv.hostPlatform;
 
-    configureFlags = with super.lib.lists; oldAttrs.configureFlags ++ [
-      "--enable-mpi"
-      "MPICC=${self.mpi}/bin/mpicc"
-      "MPIFC=${self.mpi}/bin/mpif90"
-      "MPIF90=${self.mpi}/bin/mpif90"
-    ];
+  # like callPackage but with override instead
+  recallPackage = pkg: inputs:
+    pkg.override ((builtins.intersectAttrs pkg.override.__functionArgs set) // inputs);
 
-    propagatedBuildInputs = oldAttrs.propagatedBuildInputs ++ [ self.mpi ];
-  });
+  set = {
+    stdenv = optStdenv;
+    cp2k = recallPackage cp2k {};
+    ergoscf = recallPackage ergoscf {};
+    hpl = recallPackage hpl {};
+    hpcg = recallPackage hpcg {};
+    i-pi = recallPackage i-pi {};
+    gsl = recallPackage gsl {};
+    mkl = recallPackage mkl {};
+    molden = recallPackage molden {};
+    mpi = recallPackage mpi {};
+    octopus = recallPackage octopus {};
+    quantum-espresso = recallPackage quantum-espresso {};
+    quantum-espresso-mpi = recallPackage quantum-espresso-mpi {};
+    pcmsolver = recallPackage pcmsolver {};
+    scalapack = recallPackage scalapack {};
+    siesta = recallPackage siesta {};
+    siesta-mpi = recallPackage siesta-mpi {};
 
-  fftwSinglePrec = self.fftw.override { precision = "single"; };
+    fftw = (recallPackage fftw {}).overrideAttrs ( oldAttrs: {
+      configureFlags = with lib; oldAttrs.configureFlags
+        ++ optional hp.avxSupport "--enable-avx"
+        ++ optional hp.avx2Support "--enable-avx2"
+        ++ optional hp.fmaSupport "--enable-fma"
+        ++ optional (hp.fmaSupport && hp.avxSupport) "--enable-avx-128-fma";
+      });
 
-  libint = super.libint.override { enableFMA = true; };
+    fftwSinglePrec = self.fftw.override { precision = "single"; };
 
-  libxsmm = super.libxsmm.overrideAttrs ( x: {
-    makeFlags = x.makeFlags ++ [ "OPT=3" "AVX=2" ];
-  });
+    fftw-mpi = self.fftw.overrideAttrs ( oldAttrs: {
+      buildInputs = oldAttrs.buildInputs ++ [ self.mpi ];
 
-  scalapack = super.scalapack.overrideAttrs ( x: {
-    CFLAGS = "-O3 -mavx2 -mavx -msse2";
-    FFLAGS = "-O3 -mavx2 -mavx -msse2";
-  });
+      configureFlags = with lib.lists; oldAttrs.configureFlags ++ [
+        "--enable-mpi"
+      ];
 
-  gromacs = super.gromacs.override {
-    cpuAcceleration = "AVX2_256";
-    singlePrec = true;
-    fftw = self.fftwSinglePrec;
+      propagatedBuildInputs = oldAttrs.propagatedBuildInputs or [] ++ [ self.mpi ];
+    });
+
+    gromacs = recallPackage gromacs {
+      cpuAcceleration = if hp.avx2Support then "AVX2_256" else null;
+      fftw = self.fftwSinglePrec;
+    };
+
+    gromacsMpi = recallPackage gromacsMpi {
+      cpuAcceleration = if hp.avx2Support then "AVX2_256" else null;
+      fftw = self.fftwSinglePrec;
+    };
+
+    gromacsDouble = recallPackage gromacsDouble {
+      cpuAcceleration = if hp.avx2Support then "AVX2_256" else null;
+    };
+
+    gromacsDoubleMpi = recallPackage gromacsDoubleMpi {
+      cpuAcceleration = if hp.avx2Support then "AVX2_256" else null;
+    };
+
+    libint = recallPackage libint { enableFMA = hp.fmaSupport; };
+
+    libxsmm = (recallPackage libxsmm {}).overrideAttrs ( x: {
+      makeFlags = x.makeFlags or [] ++ [ "OPT=3" ]
+        ++ lib.optional hp.avx2Support ["AVX=2" ];
+    });
+
+    hostPlatform = hp;
   };
 
-  gromacsMpi = super.gromacs.override {
-    cpuAcceleration = "AVX2_256";
-    singlePrec = true;
-    mpiEnabled = true;
-    fftw = self.fftwSinglePrec;
-  };
-
-  gromacsDouble = super.gromacs.override {
-    cpuAcceleration = "AVX2_256";
-    singlePrec = false;
-    fftw = self.fftw;
-  };
-
-  gromacsDoubleMpi = super.gromacs.override {
-    cpuAcceleration = "AVX2_256";
-    singlePrec = false;
-    mpiEnabled = true;
-    fftw = self.fftw;
-  };
-}
+in set

--- a/nixpkgs-opt.nix
+++ b/nixpkgs-opt.nix
@@ -16,11 +16,14 @@ let
   set = {
     stdenv = optStdenv;
     cp2k = recallPackage cp2k {};
+    dkh = recallPackage dkh {};
     ergoscf = recallPackage ergoscf {};
     hpl = recallPackage hpl {};
     hpcg = recallPackage hpcg {};
     i-pi = recallPackage i-pi {};
     gsl = recallPackage gsl {};
+    libvori = recallPackage libvori {};
+    libxc = recallPackage libxc {};
     mkl = recallPackage mkl {};
     molden = recallPackage molden {};
     mpi = recallPackage mpi {};
@@ -31,6 +34,7 @@ let
     scalapack = recallPackage scalapack {};
     siesta = recallPackage siesta {};
     siesta-mpi = recallPackage siesta-mpi {};
+    spglib = recallPackage spglib {};
 
     fftw = (recallPackage fftw {}).overrideAttrs ( oldAttrs: {
       configureFlags = with lib; oldAttrs.configureFlags

--- a/pkgs/apps/bagel/default.nix
+++ b/pkgs/apps/bagel/default.nix
@@ -2,7 +2,6 @@
 , makeWrapper, openssh
 , python3, boost, mpi, blas, lapack
 , scalapack ? null
-, optAVX ? true
 } :
 
 let
@@ -44,7 +43,6 @@ in stdenv.mkDerivation rec {
     "-O3"
     "-DCOMPILE_J_ORB"
   ] ++ lib.lists.optionals (!useMKL) [ "-lblas" "-llapack" ]
-    ++ lib.lists.optional optAVX "-mavx -mavx2"
     ++ lib.lists.optional (blas.passthru.implementation == "openblas") "-DZDOT_RETURN"
   );
 


### PR DESCRIPTION
This PR cleans up the optimization of upstream packages and adds the possibility of adding gcc optimization flags to stdenv.

Up till now the overlay applied overrides upstream packages directly in the nixpkgs name space. This is in fact a bug as it causes mass rebuilds on packages that not related to the overlay (e.g. the fftw overrides causes a rebuild of firefox). This has been changed. The overrides only affect packages in the `qchem` subset. 

A new config option `optArch` is introduced, which adds `march` and `mtune` flags to the stdenv.