### PR TITLE
pysisyphus: 0.7.post1 -> 0.7.2

### DIFF
--- a/pkgs/apps/pysisyphus/default.nix
+++ b/pkgs/apps/pysisyphus/default.nix
@@ -105,6 +105,8 @@ in
       sha256 = "wO/D7ySH0g/qN2aqzOF2Be3aw3U248dvuIEaTAkFYC4=";
     };
 
+    patches = [ ./scikit-learn.patch ];
+
     # Requires at least PySCF
     doCheck = pyscf != null;
 

--- a/pkgs/apps/pysisyphus/default.nix
+++ b/pkgs/apps/pysisyphus/default.nix
@@ -1,7 +1,7 @@
 { fetchPypi, fetchFromGitHub, buildPythonPackage, lib, writeTextFile, writeScript, makeWrapper,
  # Python dependencies
  autograd, dask, distributed, h5py, jinja2, matplotlib, numpy, natsort, pytest, pyyaml, rmsd, scipy,
- sympy, scikitlearn, qcengine, ase, xtb-python, openbabel-bindings,
+ sympy, scikit-learn, qcengine, ase, xtb-python, openbabel-bindings,
  # Runtime dependencies
  runtimeShell, jmol ? null, multiwfn ? null, xtb ? null, openmolcas ? null,
  pyscf ? null, psi4 ? null, wfoverlap ? null, nwchem ? null, orca ? null,
@@ -58,7 +58,7 @@ let
 in
   buildPythonPackage rec {
     pname = "pysisyphus";
-    version = "0.7.post1";
+    version = "0.7.2";
 
     nativeBuildInputs = [ makeWrapper ];
 
@@ -75,7 +75,7 @@ in
       rmsd
       scipy
       sympy
-      scikitlearn
+      scikit-learn
       qcengine
       ase
       openbabel-bindings
@@ -102,7 +102,7 @@ in
       owner = "eljost";
       repo = pname;
       rev = version;
-      sha256 = "1zw2f083x8z3sqyqfs1mak69db017kiclbk2pgjhcqml45737fnh";
+      sha256 = "wO/D7ySH0g/qN2aqzOF2Be3aw3U248dvuIEaTAkFYC4=";
     };
 
     # Requires at least PySCF

--- a/pkgs/apps/pysisyphus/scikit-learn.patch
+++ b/pkgs/apps/pysisyphus/scikit-learn.patch
@@ -1,0 +1,13 @@
+diff --git a/setup.py b/setup.py
+index ae250ea0..2e604e96 100644
+--- a/setup.py
++++ b/setup.py
+@@ -42,7 +42,7 @@ setup(
+         "rmsd",
+         "scipy>=1.4.1",
+         "sympy>=1.5.1",
+-        "scikit-learn>=0.24.2",
++        "scikit-learn>=0.24.1",
+     ],
+     # Install locally with
+     #   pip install -e .[extra]


### PR DESCRIPTION
Update of Pysisphus with important updates to TRIC coordinate optimisation and excited state optimisation.

Requires https://github.com/NixOS/nixpkgs/pull/137267 to appear in nixpkgs-unstable first.