### PR TITLE
XTBPATH Environment

### DIFF
--- a/pkgs/apps/xtb/default.nix
+++ b/pkgs/apps/xtb/default.nix
@@ -50,9 +50,10 @@ in stdenv.mkDerivation rec {
 
   postFixup = ''
     wrapProgram $out/bin/xtb \
-      --prefix PATH : "${binSearchPath}" \
-      --set-default XTBPATH "$out/share/xtb"
+      --prefix PATH : "${binSearchPath}"
   '';
+
+  setupHooks = [ ./xtbHook.sh ];
 
   meta = with lib; {
     inherit description;

--- a/pkgs/apps/xtb/xtbHook.sh
+++ b/pkgs/apps/xtb/xtbHook.sh
@@ -1,0 +1,1 @@
+export XTBPATH=@out@/share/xtb


### PR DESCRIPTION
This always sets the `XTBPATH` environment, not just for the executable. This is relevant for the C- and Python-APIs, which do not see this variable otherwise and can't perform GFN-0 calculations.

cc @eljost