### PR TITLE
pysisyphus: relax h5py version constraint

### DIFF
--- a/pkgs/apps/pysisyphus/default.nix
+++ b/pkgs/apps/pysisyphus/default.nix
@@ -105,7 +105,10 @@ in
       sha256 = "wO/D7ySH0g/qN2aqzOF2Be3aw3U248dvuIEaTAkFYC4=";
     };
 
-    patches = [ ./scikit-learn.patch ];
+    patches = [
+      ./scikit-learn.patch
+      ./h5py.patch
+    ];
 
     # Requires at least PySCF
     doCheck = pyscf != null;

--- a/pkgs/apps/pysisyphus/h5py.patch
+++ b/pkgs/apps/pysisyphus/h5py.patch
@@ -1,0 +1,13 @@
+diff --git a/setup.py b/setup.py
+index ae250ea0..85d97a95 100644
+--- a/setup.py
++++ b/setup.py
+@@ -32,7 +32,7 @@ setup(
+         "autograd",
+         "dask",
+         "distributed",
+-        "h5py==3.2.1",
++        "h5py",
+         "jinja2",
+         "matplotlib",
+         "numpy>=1.18.1",


### PR DESCRIPTION
The strict version constraint stems only from the PySCF incompatibility with recent h5py versions. I have relaxed it, as PySCF itself now has been fixed to work with recent h5py.