### PR TITLE
psi4: 1.4.1 -> 1.5

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1637534296,
-        "narHash": "sha256-Z/kBY/Ckcl7ZKao/1RUrSGBCokCZVnB8aQPrzo8FMhs=",
+        "lastModified": 1638189734,
+        "narHash": "sha256-Vks5UgpFqbrSNi3RXaozVWAVEfueplN2WBPs2bRajHA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "25e036ff5d2c9cd9382bbb1bbe0d929950c1449f",
+        "rev": "f366af7a1b3891d9370091ab03150d3a6ee138fa",
         "type": "github"
       },
       "original": {

--- a/pkgs/apps/psi4/default.nix
+++ b/pkgs/apps/psi4/default.nix
@@ -68,7 +68,7 @@ let
 
 in buildPythonPackage rec {
     pname = "psi4";
-    version = "1.4.1";
+    version = "1.5";
 
     nativeBuildInputs = [
       cmake
@@ -116,7 +116,7 @@ in buildPythonPackage rec {
       repo = pname;
       owner = "psi4";
       rev = "v${version}";
-      sha256 = "g/cu087wwK/y37E86/noBUCGQiqYDPCihlVJf7yK7kA=";
+      sha256 = "sha256-NVpE5fAVWYlkymTrvptZ7xqu68eVy71YJ+dRdBMMU9c=";
     };
 
     patches = [ ./LibintCmake.patch ];


### PR DESCRIPTION
Update to the latest upsteam release, unfortunately still with the original Libint2 hack as upstream (the build times are terrible).
https://github.com/psi4/psi4/releases/tag/v1.5