### PR TITLE
crest: 2.11.1 -> 2.11.2

### DIFF
--- a/pkgs/apps/crest/default.nix
+++ b/pkgs/apps/crest/default.nix
@@ -1,10 +1,25 @@
-{ stdenv, lib, fetchurl, makeWrapper, cmake
-, gfortran, mkl, fetchFromGitHub, xtb
+{ stdenv, lib, fetchpatch, makeWrapper, cmake
+, gfortran, blas, lapack, fetchFromGitHub, xtb
 } :
 
 stdenv.mkDerivation rec {
   pname = "crest";
-  version = "2.11.1";
+  version = "2.11.2";
+
+  src = fetchFromGitHub {
+    owner = "grimme-lab";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-IdGo8VdUdw2GtWUaQywiJwhR20XNSEsZbGsGCmzsRlg=";
+  };
+
+  patches = [
+    # gfortran compilation issues due to non-standard use of .eq. instead of .eqv.
+    (fetchpatch {
+      url = "https://patch-diff.githubusercontent.com/raw/grimme-lab/crest/pull/92.diff";
+      sha256 = "0sdd7lpnhrrfagidfg438gv011mrmvdlpnnispcvjcbs7zxzzk2a";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake
@@ -12,14 +27,7 @@ stdenv.mkDerivation rec {
     gfortran
   ];
 
-  buildInputs = [ mkl ];
-
-  src = fetchFromGitHub {
-    owner = "grimme-lab";
-    repo = pname;
-    rev = "v${version}";
-    sha256 = "/6f5MH+0AHXrVC26KA3fXTrJYuNSfeW3H79dJPMjuRw=";
-  };
+  buildInputs = [ blas lapack ];
 
   FFLAGS = "-ffree-line-length-512";
 


### PR DESCRIPTION
Minor update, that allows for compilation with other BLAS/LAPACK implementations than MKL. This makes also CREST a free derivation, that can be built and cached.
Also adds explicit solvent models.