### PR TITLE
bagel: pin boost and fix optional MPI

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -106,7 +106,10 @@ let
           boost = final.boost165;
         };
 
-        bagel-serial = callPackage ./pkgs/apps/bagel { mpi = null; };
+        bagel-serial = callPackage ./pkgs/apps/bagel {
+          enableMpi = false;
+          boost = final.boost165;
+        };
 
         cefine = self.nullable self.turbomole (callPackage ./pkgs/apps/cefine { });
 


### PR DESCRIPTION
* Cleanup optional MPI and Scalapack. Add `enableMpi` and `enableScalapack` instead `null` inputs (booth are default true)
* PIn boost version also for `bagel-serial`