### PR TITLE
updated URL for the  NWChem website

### DIFF
--- a/pkgs/apps/nwchem/default.nix
+++ b/pkgs/apps/nwchem/default.nix
@@ -153,7 +153,7 @@ in stdenv.mkDerivation {
     description = "Open Source High-Performance Computational Chemistry";
     platforms = [ "x86_64-linux" ];
     maintainers = [ maintainers.markuskowa ];
-    homepage = "http://www.nwchem-sw.org";
+    homepage = "https://nwchemgit.github.io";
     license = {
       fullName = "Educational Community License, Version 2.0";
       url = "https://opensource.org/licenses/ECL-2.0";


### PR DESCRIPTION
The old NWChem website has been take over by cyber squatters. Please do use the current website https://nwchemgit.github.io