### PR TITLE
veloxchem: init at 2022-01-07

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -235,6 +235,8 @@ let
 
         turbomole = callPackage ./pkgs/apps/turbomole { };
 
+        veloxchem = super.python3.pkgs.toPythonApplication self.python3.pkgs.veloxchem;
+
         vmd =
           if cfg.useCuda
           then callPackage ./pkgs/apps/vmd/binary.nix { }

--- a/pkgs/apps/veloxchem/default.nix
+++ b/pkgs/apps/veloxchem/default.nix
@@ -1,0 +1,77 @@
+{ buildPythonPackage, lib, fetchFromGitLab, rsync
+, mpi, xtb, blas
+, mpi4py, numpy, pybind11, h5py, psutil, geometric
+, pytest, pytest-cov, openssh
+}:
+
+assert !blas.isILP64;
+
+buildPythonPackage rec {
+  pname = "veloxchem";
+  version = "2022-01-07";
+
+  src = fetchFromGitLab {
+    owner = pname;
+    repo = pname;
+    rev = "17bbbb43972baafeef517bee7ff147e2c04fa28e";
+    sha256 = "1piqm9hsbgm0rf8xakf4c5jhggl7n362mvq0zn8a1x1x00k0bg1i";
+  };
+
+  preBuild = ''
+    export VLX_NUM_BUILD_JOBS=$NIX_BUILD_CORES
+
+    export MPICXX=mpicxx
+
+    # The setup script requires OPENBLASROOT or MKLROOT
+    ${if blas.passthru.provider.pname == "openblas"
+      then "export OPENBLASROOT=${blas.passthru.provider.dev}"
+      else if blas.passthru.provider.pname == "mkl"
+      then "export MKLROOT=${blas.passthru.provider.dev}"
+      else ""}
+  '';
+
+  nativeBuildInputs = [
+    rsync
+    mpi
+    pytest
+  ];
+
+  buildInputs = [
+    blas.passthru.provider.outPath
+  ];
+
+  propagatedBuildInputs = [
+    numpy
+    h5py
+    geometric
+    mpi
+    pybind11
+    psutil
+    mpi4py
+    xtb
+  ];
+
+  checkInputs = [
+    openssh # needed for openmpi
+    pytest
+  ];
+
+  checkPhase = ''
+    export OMP_NUM_THREADS=1
+    export OMPI_MCA_rmaps_base_oversubscribe=1
+    export MV2_ENABLE_AFFINITY=0
+    # Fix to make mpich run in a sandbox
+    export HYDRA_IFACE=lo
+
+    cd python_tests
+    mpirun -np 2 python3 -m pytest
+  '';
+
+  meta = with lib; {
+    description = "Quantum chemistry software for the calculation of molecular properties and spectroscopies";
+    homepage = "https://veloxchem.org";
+    license = [ licenses.lgpl3 ];
+    maintainers = [ maintainers.markuskowa ];
+  };
+}
+

--- a/pythonPackages.nix
+++ b/pythonPackages.nix
@@ -42,6 +42,8 @@ let
 
     rmsd = callPackage ./pkgs/lib/rmsd { };
 
+    veloxchem = callPackage ./pkgs/apps/veloxchem { };
+
     xtb-python = callPackage ./pkgs/lib/xtb-python { };
   } // lib.optionalAttrs super.isPy27 {
     pyquante = callPackage ./pkgs/apps/pyquante { };


### PR DESCRIPTION
Veloxchem is a successor of Dalton. Seems to work. However, I could not make the CPPPE support work, since it requires an old version.