### PR TITLE
gamess-us: compatibility qcengine, pysisyphus: optional gamess

### DIFF
--- a/pkgs/apps/gamess-us/default.nix
+++ b/pkgs/apps/gamess-us/default.nix
@@ -73,8 +73,6 @@ in stdenv.mkDerivation rec {
       export target=${target}
       substituteAllInPlace rungms
 
-      head -n 200 rungms
-
       # Make config accept dynamic OpenBLAS
       substituteInPlace config --replace "libopenblas.a" "libopenblas.so"
       substituteInPlace lked --replace "libopenblas.a" "libopenblas.so"
@@ -123,8 +121,7 @@ in stdenv.mkDerivation rec {
     mkdir -p $out/bin $out/share $out/share/gamess
 
     # Copy the interesting scripts and executables
-    cp gamess.${version}.x rungms $out/bin/.
-    cp $(find -name ddikick.x) $out/bin/.
+    cp gamess.${version}.x rungms ${lib.strings.optionalString (!enableMpi) "ddi/ddikick.x"} $out/bin/.
 
     # Copy the file definitions to share
     cp gms-files.csh $out/share/gamess/.

--- a/pkgs/apps/gamess-us/default.nix
+++ b/pkgs/apps/gamess-us/default.nix
@@ -1,5 +1,6 @@
 { stdenv, lib, makeWrapper, fetchFromGitLab, requireFile, gfortran, writeTextFile, cmake, perl
 , tcsh, mpi, blas, hostname, openssh, gnused, libxc, ncurses
+, enableMpi ? true
 }:
 assert
   lib.asserts.assertMsg
@@ -11,7 +12,8 @@ assert
   (blas.isILP64)
   "A 64 bit integer implementation of BLAS is required.";
 
-stdenv.mkDerivation rec {
+let target = if enableMpi then "mpi" else "sockets";
+in stdenv.mkDerivation rec {
   pname = "gamess-us";
   version = "2021R2P1";
 
@@ -68,7 +70,10 @@ stdenv.mkDerivation rec {
       # Prepare the rungms script -> replace references to @version@ and @out@
       export mpiname=${mpiname}
       export mpiroot=${mpiroot}
+      export target=${target}
       substituteAllInPlace rungms
+
+      head -n 200 rungms
 
       # Make config accept dynamic OpenBLAS
       substituteInPlace config --replace "libopenblas.a" "libopenblas.so"
@@ -94,9 +99,7 @@ stdenv.mkDerivation rec {
        else "${blas.passthru.provider}/lib"
     }
 
-    mpi
-    ${mpi.pname}
-    ${mpi}
+    ${if enableMpi then "${target}\n${mpi.pname}\n${mpi}" else target}
     no
     no
     no
@@ -121,6 +124,7 @@ stdenv.mkDerivation rec {
 
     # Copy the interesting scripts and executables
     cp gamess.${version}.x rungms $out/bin/.
+    cp $(find -name ddikick.x) $out/bin/.
 
     # Copy the file definitions to share
     cp gms-files.csh $out/share/gamess/.
@@ -149,7 +153,7 @@ stdenv.mkDerivation rec {
     # MPI fixes in sandbox
     export HYDRA_IFACE=lo
     export OMPI_MCA_rmaps_base_oversubscribe=1
-    
+
     $out/bin/rungms $out/share/gamess/tests/mcscf/mrpt/parallel/mc-detpt-bic-short.inp ${version} 2 2
   '';
 

--- a/pkgs/apps/gamess-us/rungms.patch
+++ b/pkgs/apps/gamess-us/rungms.patch
@@ -10,7 +10,7 @@ index d4cd542..be65ff0 100755
 -set SCR=~/gamess/restart
 -set USERSCR=~/gamess/restart
 -set GMSPATH=~/gamess
-+set TARGET=mpi
++set TARGET=@target@
 +set SCR=$SCRATCH
 +set USERSCR=$SCRATCH
 +set GMSPATH=@out@/bin
@@ -22,7 +22,7 @@ index d4cd542..be65ff0 100755
  #
  # provide defaults if last two arguments are not given to this script
 -if (null$VERNO == null) set VERNO=00
-+if (null$VERNO == null) set VERNO=@version@
++if (null$VERNO == null || $VERNO == "00") set VERNO=@version@
  if (null$NCPUS == null) set NCPUS=1
  if (null$LOGN == null) set LOGN=0
  #

--- a/pythonPackages.nix
+++ b/pythonPackages.nix
@@ -33,11 +33,9 @@ let
     psi4 = callPackage ./pkgs/apps/psi4 { };
 
     pysisyphus = callPackage ./pkgs/apps/pysisyphus {
-      enableXtb = true;
-      enableNwchem = true;
-      enableJmol = true;
-      enableWfoverlap = true;
-      enableOpenmolcas = true;
+      gamess-us = selfPkgs.gamess-us.override {
+        enableMpi = false;
+      };
     };
 
     rmsd = callPackage ./pkgs/lib/rmsd { };


### PR DESCRIPTION
To work with QCEngine and Pysisyphus, a few tweaks to GAMESS-US are required:
- the socket version is required, thus `enableMpi` allows to disable MPI in GAMESS-US
- the scratch directories need to be set to `./` for qcengine

Pysisyphus was updated to have a GAMESS-US option and now uses the pyproject build instead of deprecated setuptools.