### PR TITLE
gamess-us: fix ddikick.x copy for sockets target

### DIFF
--- a/pkgs/apps/gamess-us/default.nix
+++ b/pkgs/apps/gamess-us/default.nix
@@ -121,7 +121,7 @@ in stdenv.mkDerivation rec {
     mkdir -p $out/bin $out/share $out/share/gamess
 
     # Copy the interesting scripts and executables
-    cp gamess.${version}.x rungms ${lib.strings.optionalString (!enableMpi) "ddi/ddikick.x"} $out/bin/.
+    cp gamess.${version}.x rungms ${lib.strings.optionalString (!enableMpi) "$(find -name ddikick.x -type f -executable)"} $out/bin/.
 
     # Copy the file definitions to share
     cp gms-files.csh $out/share/gamess/.


### PR DESCRIPTION
The ddikick installation from PR #140 did not work, this fixes it for both the socket target, so that both socket and mpi work now.