### PR TITLE
xtb-python: fix meson install

### DIFF
--- a/pkgs/lib/xtb-python/default.nix
+++ b/pkgs/lib/xtb-python/default.nix
@@ -1,5 +1,5 @@
 { buildPythonPackage, lib, fetchFromGitHub, cffi, numpy, ase, qcelemental, meson, ninja, pkg-config,
-  xtb, pytest
+  xtb, pytestCheckHook, python
 }:
 
 buildPythonPackage rec {
@@ -33,13 +33,14 @@ buildPythonPackage rec {
 
   # Build a C module to interface XTB.
   preBuild = ''
-    meson setup build --prefix=$PWD --default-library=shared
+    meson setup build --prefix=$(pwd) --default-library=shared
     ninja -C build install
+    cp ./${python.passthru.sitePackages}/_libxtb.*.so ./xtb/.
   '';
 
-  checkInputs = [ pytest ];
-  checkPhase = "pytest";
-  doCheck = false;
+  checkInputs = [ pytestCheckHook ];
+  pytestFlagsArray = [ "-k 'not qcschema'" ]; # Numerically soooo slightly off
+  pythonImportsCheck = [ "xtb.interface" "xtb.libxtb" ];
 
   meta = with lib; {
     description = "Python wrapper for the semiempirical XTB package";


### PR DESCRIPTION
Closes #151
Caused by the upstream meson update, which now changes how the C-library for XTB is installed. A manual copy fixes this. I've also enabled the XTB-Python tests to track down the problem in the future more easily.