### PR TITLE
pysisyphus: fix hash

### DIFF
--- a/pkgs/apps/pysisyphus/default.nix
+++ b/pkgs/apps/pysisyphus/default.nix
@@ -115,7 +115,7 @@ in
       owner = "eljost";
       repo = pname;
       rev = version;
-      hash = "sha256-AvJ/9+63yxfeCvL2gRmdZMt/GbvRzMbwlGgOwS2Rrek=";
+      hash = "sha256-CGV/vqeFiG5DYb6w6rQ7rwTPeE9DL8891fXraSWn2Rs=";
     };
 
     format = "pyproject";


### PR DESCRIPTION
Somehow the Pysisyphus hash was wrong. I have no idea why and when, but it should work again, now.