### PR TITLE
gdma: patch to accept longer file names

### DIFF
--- a/pkgs/apps/gdma/default.nix
+++ b/pkgs/apps/gdma/default.nix
@@ -19,6 +19,7 @@ stdenv.mkDerivation rec {
     leaveDotGit = true;
   };
 
+  patches = [ ./filepath.patch ];
   postPatch = "patchShebangs src/version.py";
 
   installPhase = ''

--- a/pkgs/apps/gdma/filepath.patch
+++ b/pkgs/apps/gdma/filepath.patch
@@ -1,0 +1,13 @@
+diff --git a/src/gdma.f90 b/src/gdma.f90
+index ae1d545..88438f3 100644
+--- a/src/gdma.f90
++++ b/src/gdma.f90
+@@ -28,7 +28,7 @@ IMPLICIT NONE
+ 
+ INTEGER, PARAMETER :: dp=kind(1d0)
+ 
+-CHARACTER(LEN=100) :: file
++CHARACTER(LEN=1000) :: file
+ CHARACTER(LEN=80) :: buffer
+ CHARACTER(LEN=20) :: key
+ CHARACTER(LEN=8) :: whichd="SCF"


### PR DESCRIPTION
We've encountered multiple issues with GDMA recently, when reading files from the nix-store (and other long paths), which were caused by the limit of file paths to 100 characters. Good old Fortran :) I had to add a patch to increase the allowed length of paths.