### PR TITLE
vmd: libGL_driver -> mesa.drivers

### DIFF
--- a/pkgs/apps/vmd/default.nix
+++ b/pkgs/apps/vmd/default.nix
@@ -32,7 +32,7 @@ let
 
     meta = with lib; {
       inherit homepage;
-      description = "Molecular dyanmics visualisation program";
+      description = "Plugins for the VMD visualisation program";
       license = licenses.unfree;
       maintainers = [ maintainers.markuskowa ];
       platforms = platforms.linux;

--- a/pkgs/apps/vmd/default.nix
+++ b/pkgs/apps/vmd/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, requireFile, perl, tcl-8_5, tk-8_5, netcdf
-, libGL_driver, libGLU, xorg, fltk, vrpn, flex, bison
+, mesa, libGLU, xorg, fltk, vrpn, flex, bison
 } :
 
 let
@@ -51,7 +51,7 @@ in stdenv.mkDerivation {
 
   nativeBuildInputs = [ perl ];
   buildInputs = [
-    plugins libGL_driver libGLU xorg.libX11
+    plugins mesa.drivers libGLU xorg.libX11
     xorg.libXinerama xorg.libXi tcl-8_5 tk-8_5 netcdf
     fltk vrpn flex bison
   ];


### PR DESCRIPTION
Has been renamed here https://github.com/NixOS/nixpkgs/pull/62167, and `libGL_driver` is ow retired.