### PR TITLE
Cachix Substituter in Flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,8 @@
 
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
+  nixConfig.extra-substituters = [ "https://nix-qchem.cachix.org" ];
+
   outputs = { self, nixpkgs } : let
       lib = import "${nixpkgs}/lib";
 
@@ -32,7 +34,11 @@
       pkgsClean = with lib; filterAttrs (n: v: isDerivation v) pkgs.qchem;
   in {
 
-    overlay = import ./overlay.nix;
+    overlays = {
+      qchem = import ./overlay.nix;
+      pythonQchem = import ./pythonPackages.nix (pkgs.config.qchem-config.prefix) (pkgs.config.qchem-config) pkgs nixpkgs;
+      default = self.overlays.qchem;
+    };
 
     packages."x86_64-linux" = pkgsClean;
     hydraJobs."x86_64-linux" = pkgsClean;


### PR DESCRIPTION
With nix >= 2.6.0 the `nixConfig` became a new configuration attribute in flakes, allowing us to directly set a substituter in the flake. Luckily, this substituter may also be used by unprivileged users, who may normally not be able to a cache.