### PR TITLE
GCC Update Fixes

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -174,6 +174,7 @@ let
 
         molcas1809 = callPackage ./pkgs/apps/openmolcas/v18.09.nix {
           blas = final.blas-ilp64;
+          gfortran = final.gfortran9;
         };
 
         molcas = callPackage ./pkgs/apps/openmolcas/default.nix {

--- a/pkgs/apps/orient/MakePrefix.patch
+++ b/pkgs/apps/orient/MakePrefix.patch
@@ -1,39 +1,23 @@
 diff --git a/Makefile b/Makefile
-index 51ae168..fcc91a9 100644
+index 6c0ad2d..ddf5728 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -23,7 +23,7 @@ COMPILER := gfortran
- #  COMPILER := ifort
- endif
+@@ -44,8 +44,8 @@ endif
  
--#  Use 
-+#  Use
- #  make OPENGL=no
- #  to over-ride this, or change it here.
- OPENGL := yes
-@@ -43,8 +43,8 @@ else
- endif
- 
- #  Choose where you want to put the installed binary. The normal make
--#  leaves a a link to the binary from ${BASE}/bin anyway. 
--PREFIX  := /usr/local
-+#  leaves a a link to the binary from ${BASE}/bin anyway.
+ #  Choose where you want 'make install' to put the installed binary.
+ #  The normal make leaves a a link to the binary from ${BASE}/bin anyway. 
+-#  PREFIX  := /usr/local
+-#  INSTALL_DIR := ${PREFIX}/bin
 +PREFIX  := ${out}
- INSTALL_DIR := ${PREFIX}/bin
++INSTALL_DIR := ${PREFIX}/bin
  
- RECIPES = /usr/local/numerical-recipes/recipes_f/recipes/
-@@ -116,7 +116,8 @@ test tests: force
+ #  Orient uses some routines from Numerical Recipes (W. H. Press et al.,
+ #  Numerical Recipes in Fortran) which cannot be distributed with the
+@@ -120,6 +120,7 @@ test tests: force
  install: ${INSTALL_DIR}/orient
  
  ${INSTALL_DIR}/orient: ${BASE}/${DIR}/orient
--	cp -p ${BASE}/${DIR}/orient ${INSTALL_DIR}
 +	mkdir -p ${INSTALL_DIR}
-+	cp -p ${BASE}/${DIR}/orient ${INSTALL_DIR}/
+ 	cp -p ${BASE}/${DIR}/orient ${INSTALL_DIR}
  
  clean:
- 	cd ${DIR}; rm *.mod *.o
-@@ -168,4 +169,3 @@ histograms.f90: %.f90: %.strip
- 
- recipes.f90:
- 	cd ${SRC}; ${BASE}/bin/patch_recipes.pl --recipes ${RECIPES} $@
--

--- a/pkgs/apps/orient/default.nix
+++ b/pkgs/apps/orient/default.nix
@@ -44,8 +44,8 @@ in stdenv.mkDerivation rec {
   # to keep the git directory.
   src = fetchgit {
     url = "https://gitlab.com/anthonyjs/${pname}.git";
-    rev = "e31e41e907d6b680a9cef2c97238b59d649f565a";
-    sha256 = "Fupi/6Yrp+tM2YVgjGMmuYKI200NMeFUbzcomKvVDCA=";
+    rev = "64cab885b460239d195c2cf239ad892fea005f22";
+    sha256 = "sha256-lJ4FyhjobJc7V9doyb6gowheKVCc27XcP36BX1Du1po=";
     leaveDotGit = true;
   };
 

--- a/pkgs/apps/pegamoid/default.nix
+++ b/pkgs/apps/pegamoid/default.nix
@@ -4,18 +4,20 @@
 
 buildPythonApplication rec {
   pname = "Pegamoid";
-  version = "2.6.1";
+  version = "2.6.2";
 
   src = fetchFromGitLab {
     owner = "jellby";
     repo = pname;
     rev = "v${version}";
-    sha256 = "10kv8gsn69p3lgg8s9ayl3v2088zladf3pabd1pqnm81cizgf5yj";
+    hash = "sha256-36ZZK2cACvrwn5EVuv+zu6oBsh3vPCZDxQGzKe4PPlg=";
   };
 
-  patches = [
-    ./pipVTK.patch
-  ];
+
+  # The samples and screenshots directories confuse setuptools and they
+  # refuse to build as long as these directories are present.
+  prePatch = "rm -rf samples screenshots";
+  patches = [ ./pipVTK.patch ];
 
   propagatedBuildInputs = [
     numpy

--- a/pkgs/apps/wfoverlap/Makefile.patch
+++ b/pkgs/apps/wfoverlap/Makefile.patch
@@ -1,37 +1,58 @@
-diff --git a/Makefile b/Makefile
-index 27b0e9a..eb95272 100644
---- a/Makefile
-+++ b/Makefile
-
+diff --git a/wfoverlap/source/Makefile b/wfoverlap/source/Makefile
+index a2f179a..17f8d90 100644
+--- a/wfoverlap/source/Makefile
++++ b/wfoverlap/source/Makefile
+@@ -33,15 +33,15 @@
+ 
+ #STATIC = -static-intel -qopenmp-link=static
+ #PROFILE = # -pg
+-OMP = -qopenmp
+-FC = ifort
++#OMP = -qopenmp
++#FC = ifort
+ #DEBUG = #-g #-warn all # -traceback -check bounds
+-OPT = -O3 -ipo
+-FCFLAGS = $(OPT) $(OMP) $(PROFILE) $(DEBUG) -fpp -i8 -DEXTBLAS
+-LINKFLAGS = $(STATIC) $(PROFILE) -z muldefs # use -z muldefs for COLUMBUS
++#OPT = -O3 -ipo
++#FCFLAGS = $(OPT) $(OMP) $(PROFILE) $(DEBUG) -fpp -i8 -DEXTBLAS
++#LINKFLAGS = $(STATIC) $(PROFILE) -z muldefs # use -z muldefs for COLUMBUS
+ 
+ # openmp (multithreaded) compilation
+-LALIB =  -Wl,--start-group ${MKLROOT}/lib/intel64/libmkl_intel_ilp64.a ${MKLROOT}/lib/intel64/libmkl_core.a ${MKLROOT}/lib/intel64/libmkl_intel_thread.a -Wl,--end-group -lpthread -lm -ldl
++#LALIB =  -Wl,--start-group ${MKLROOT}/lib/intel64/libmkl_intel_ilp64.a ${MKLROOT}/lib/intel64/libmkl_core.a ${MKLROOT}/lib/intel64/libmkl_intel_thread.a -Wl,--end-group -lpthread -lm -ldl
+ #LALIB  = -Wl,--start-group  $(MKLROOT)/lib/intel64/libmkl_intel_ilp64.a $(MKLROOT)/lib/intel64/libmkl_sequential.a $(MKLROOT)/lib/intel64/libmkl_core.a -Wl,--end-group -lm
+ 
+ 
+@@ -49,10 +49,10 @@ LALIB =  -Wl,--start-group ${MKLROOT}/lib/intel64/libmkl_intel_ilp64.a ${MKLROOT
+ 
+ # **** gfortran ****
+ 
+-#FC = gfortran
+-#FCFLAGS = -O0 -cpp -g3 -fdefault-integer-8 -Wall -fbacktrace -DEXTBLAS
+-#LINKFLAGS = 
+-#LALIB = -lblas -llapack -fopenmp
++FC = gfortran
++FCFLAGS = -O0 -cpp -g3 -fdefault-integer-8 -Wall -fbacktrace -DEXTBLAS -fallow-argument-mismatch
++LINKFLAGS = 
++LALIB = -lblas -llapack -fopenmp
+ 
  ############## Main objects and libraries #######
-
+ 
 @@ -62,12 +62,12 @@ DUMMYOBS=read_dalton_dummy.o read_molcas_dummy.o
-
+ 
  ############## Dalton and SEWARD ################
  # no Dalton and SEWARD support
 -#LIBS = $(LALIB)
 -#OPTOBS = $(DUMMYOBS)
 +LIBS = $(LALIB)
 +OPTOBS = $(DUMMYOBS)
-
+ 
  # activate direct reading of Dalton and Seward files
- #LIBS = $(COLUMBUS)/libmolcas_col.a $(COLUMBUS)/colib.a $(COLUMBUS)/blaswrapper.a  $(LALIB)
+-LIBS = $(MOLCAS)/lib/libmolcas.a $(COLUMBUS)/colib.a $(COLUMBUS)/blaswrapper.a  $(LALIB)
 -OPTOBS = read_dalton.o read_molcas.o
++#LIBS = $(MOLCAS)/lib/libmolcas.a $(COLUMBUS)/colib.a $(COLUMBUS)/blaswrapper.a  $(LALIB)
 +#OPTOBS = read_dalton.o read_molcas.o
-
- ############## Compilation routines #############
-
-@@ -80,13 +80,10 @@ OPTOBS = read_dalton.o read_molcas.o
-
- wfoverlap.x : main.f90 $(MAINOBS) $(OPTOBS) iomod.o
- 	$(FC) $(FCFLAGS) $(LINKFLAGS) $(PROFILE) $^ -o $@ $(LIBS)
--	cp $@ ../../bin
-
- # executable that is linked to dummy I/O interfaces and that reads only ASCII files
- wfoverlap_ascii.x : main.f90 $(MAINOBS) $(DUMMYOBS) iomod.o
- 	$(FC) $(FCFLAGS) $(LINKFLAGS) $(PROFILE) $^ -o $@ $(LALIB)
--	cp $@ ../../bin
--	ln -fs $@ ../../bin/wfoverlap.x
-
- alloc:
- 	./write_allocmod.pl > my_alloc.f90
+ 
+ # activate direct reading of only Seward files
+ # LIBS = $(MOLCAS)/lib/libmolcas.a $(LALIB)

--- a/pkgs/apps/wfoverlap/default.nix
+++ b/pkgs/apps/wfoverlap/default.nix
@@ -7,21 +7,19 @@ assert
 
 assert
   lib.asserts.assertMsg
-  (lapack.isILP64)
+  lapack.isILP64
   "64 bit integer LAPACK implementation required.";
 
 stdenv.mkDerivation rec {
   pname = "wfoverlap";
   version = "24.08.2020";
 
-  src = let
-    repo = fetchFromGitHub {
-      owner = "sharc-md";
-      repo = "sharc";
-      rev = "d943ec7aff0fb6c81f61d3c057b0921d053e9e20";
-      sha256 = "1a9frnxvm1jg4cv3jd4lm3q8m7igyc7fsp3baydfjkvk0b4ss9bc";
-    };
-  in "${repo}/wfoverlap/source";
+  src = fetchFromGitHub {
+    owner = "felixplasser";
+    repo = "wfoverlap";
+    rev = "76b51533770aaf32732e942cd81e6aa12770900e";
+    hash = "sha256-bA8XRYGyCDDJ0dzCw5BDSJf+wcRj9A9mTfm+ukrbrlg=";
+  };
 
   nativeBuildInputs = [ gfortran ];
 
@@ -34,6 +32,8 @@ stdenv.mkDerivation rec {
   patches = [ ./Makefile.patch ];
 
   dontConfigure = true;
+
+  preBuild = "cd wfoverlap/source";
 
   hardeningDisable = [ "format" ];
 


### PR DESCRIPTION
This fixes some of the problems described in #186 

- `orient` fixed by upstream updates
- `wfoverlap` fixed by upstream updates
- `pegamoid` fixed by upstream updates, but other issues were introduced with setuptools, that I circumvent in the update
- `molcas1809` has probably no easy fix for this old version, except actually patching all type mismatches. I vote for just pinning gfortran to gfortran9. The hard reality is probably, that it is not viable to support outdated versions of software for new compiler versions forever. Although it would be sad to drop it entirely as this is the last supported version for SHARC, SHARC also runs fine with newer versions. Then again SHARC is also slowly dying as they refuse to update to Python3. I am open to just remove `molcas1809`
- `iboview` has a wrong type annotation *somewhere*. It basically constructs a set or dict somewhere from values, which are not declared as const. In the new libc++/glibc versions this is an error, as these ordered structures would be invalidated by intransparently changing values in them. Unfortunately I am completely lost in the mysteries C++ code and errors are to me and I have absolutely no idea where this would need to be fixed. It is probably just a `const` declaration missing at 2 or 3 positions.  The short term solution is to also pin the gcc version to 9 ... I am OK with it until upstream fixes it properly. What do you think?

