### PR TITLE
exatensor: 2020-07-15 -> 2022-05-07

### DIFF
--- a/pkgs/apps/exatensor/default.nix
+++ b/pkgs/apps/exatensor/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, lib, fetchFromGitLab, blas, mpi } :
+{ stdenv, lib, fetchFromGitLab, blas, mpi, cudaPackages, which } :
 
 let
-  version = "2020-07-15";
+  version = "2022-05-07";
 
 in stdenv.mkDerivation rec {
   pname = "exatensor";
@@ -9,36 +9,48 @@ in stdenv.mkDerivation rec {
 
   src = fetchFromGitLab {
     owner = "DmitryLyakh";
-    repo = pname;
-    rev = "d304c03b7289525f250245ece1b4a13a5973fef4";
-    sha256 = "0zlqwpdqfycwvys39lvvj94cprhaxmyaxxs1c66f10dazjbafp49";
+    repo = "ExaTENSOR";
+    rev = "7a75a73bc6dbfa3ff4b107231514d8f3d26e6338";
+    hash = "sha256-nczcRWT/mh9yGM5qON7Zgqw/gpI1Jx7SSMlfublEgAg=";
   };
 
-  postPatch = ''
-    substituteInPlace DDSS/Makefile --replace 'FFLAGS =' 'FFLAGS = -fallow-argument-mismatch';
-    substituteInPlace INTRAVIRT/Makefile --replace 'FFLAGS =' 'FFLAGS = -fallow-argument-mismatch';
-    substituteInPlace INTERVIRT/Makefile --replace 'FFLAGS =' 'FFLAGS = -fallow-argument-mismatch';
-  '';
+  nativeBuildInputs = [
+    cudaPackages.cuda_nvcc
+    which
+  ];
 
-  buildInputs = [ blas.passthru.provider ];
+  buildInputs = [
+    blas.passthru.provider 
+    cudaPackages.cuda_cudart
+    cudaPackages.cuda_nvtx
+    cudaPackages.libcublas
+  ];
 
-  MPILIB = if (mpi.pname == "openmpi") then "OPENMPI"
-    else if (mpi.pname == "mpich") then "MPICH"
-    else throw "Only openmpi and mpich supported by ${pname}.";
+  preConfigure = 
+    let
+      MPILIB = if (mpi.pname == "openmpi") then "OPENMPI"
+        else if (mpi.pname == "mpich") then "MPICH"
+        else if (mpi.pname == "mvapich") then "MPICH"
+        else throw "Only openmpi, mpich and mvapich supported by ${pname}.";
+      BLASLIB =
+        if (blas.passthru.implementation == "openblas") then "OPENBLAS"
+          else if (blas.passthru.implementation == "mkl") then "MKL"
+          else throw "Only MKL and OPENBLAS supported by ${pname}.";
+    in ''
+      export CUDA_HOST_COMPILER=$(which g++)
+      export MPILIB=${MPILIB}
+      export PATH_OPENMPI=${mpi}
+      export PATH_MPICH=${mpi}
+      export BLASLIB=${BLASLIB}
+      export PATH_BLAS_OPENBLAS=${blas.passthru.provider}
+      export PATH_BLAS_MKL=${blas.passthru.provider};
+      export PATH_BLAS_MKL_DEP="${blas.passthru.provider}/lib";
+      export PATH_BLAS_MKL_INC="${blas.passthru.provider}/include";
+    '';
 
-  PATH_OPENMPI = mpi;
-  PATH_MPICH = mpi;
-
-  BLASLIB =
-    if (blas.passthru.implementation == "openblas") then "OPENBLAS"
-    else if (blas.passthru.implementation == "mkl") then "MKL"
-    else throw "Only MKL and OPENBLAS supported by ${pname}.";
-
-  PATH_BLAS_OPENBLAS = blas.passthru.provider;
-  PATH_BLAS_MKL = blas.passthru.provider;
-  PATH_BLAS_MKL_DEP = "${blas.passthru.provider}/lib";
-  PATH_BLAS_MKL_INC = "${blas.passthru.provider}/include";
-
+  enableParalleBuilding = true;
+  hardeningDisable = [ "format" ];
+  
   installPhase = ''
     mkdir -p $out/lib $out/bin $out/include
     cp -r ./bin/* $out/bin
@@ -46,9 +58,9 @@ in stdenv.mkDerivation rec {
     cp -r ./include/* $out/include
   '';
 
+
   meta = with lib; {
-    description = "ExaTENSOR is a basic numerical tensor algebra library for
-distributed HPC systems equipped with multicore CPU and NVIDIA or AMD GPU.";
+    description = "ExaTENSOR is a basic numerical tensor algebra library for distributed HPC systems equipped with multicore CPU and NVIDIA or AMD GPU.";
     homepage = "https://gitlab.com/DmitryLyakh/ExaTensor";
     license = licenses.lgpl3Only;
     platforms = platforms.linux;


### PR DESCRIPTION
Exatensor, here we are! Unfortunately now requires Cuda. Then again its a library for computations on GPUs, so that's probably fair.

Unfortunately it breaks linking in DIRAC, as this misses some CUDA libraries now.