### PR TITLE
Use composeExtensions to preserve existing Python package overrides

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -281,8 +281,13 @@ let
         xtb = callPackage ./pkgs/apps/xtb { };
 
         ### Python packages
-        python3 = super.python3.override { packageOverrides = pythonOverrides cfg self super; };
-        python2 = super.python2.override { packageOverrides = pythonOverrides cfg self super; };
+        python3 = super.python3.override (old: {
+          packageOverrides = super.lib.composeExtensions (old.packageOverrides or (_: _: { })) (pythonOverrides cfg self super);
+        });
+
+        python2 = super.python2.override (old: {
+          packageOverrides = super.lib.composeExtensions (old.packageOverrides or (_: _: { })) (pythonOverrides cfg self super);
+        });
 
         #
         # Libraries


### PR DESCRIPTION
Resolves #183 

This PR addresses the scenario where the qchem overlay is applied after another overlay that overrides Python packages. Currently, the previously-applied overrides will be lost due to Python overrides not composing by default (https://github.com/NixOS/nixpkgs/issues/44426).

The following is a minimal reproduction:

```nix
let
  qchemOverlay = import ./overlay.nix;

  myOverlay = _: prev: {
    python3 = prev.python3.override {
      packageOverrides = (_: _: { foo = 42; });
    };
  };

  pkgs = import <nixpkgs> {
    overlays = [
      myOverlay
      qchemOverlay
    ];
  };
in
pkgs.qchem.python3.pkgs.foo
```
Currently, this expression fails to evaluate:
```
$ nix eval -f test.nix
error: attribute 'foo' missing
```

This PR modifies the qchem overlay to preserve existing overrides, using the variant of `override` that accepts a function from old to new overrides and `lib.composeExtensions`. This is similar to the approach used in [tweag/jupyterWith](https://github.com/tweag/jupyterWith/blob/93f75799b527b03de9acc09ae18cc4b8817fb0c5/nix/python-overlay.nix#L97-L102).