### PR TITLE
Psi4 Update

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -310,6 +310,8 @@ let
 
         amd-scalapack = callPackage ./pkgs/lib/amd-scalapack { };
 
+        libecpint = callPackage ./pkgs/lib/libecpint { };
+
         libefp = callPackage ./pkgs/lib/libefp { };
 
         libGDSII = callPackage ./pkgs/lib/libGDSII { };

--- a/pkgs/lib/libecpint/default.nix
+++ b/pkgs/lib/libecpint/default.nix
@@ -1,0 +1,43 @@
+{ lib, stdenv, fetchFromGitHub, cmake, pugixml, python3, gtest }:
+
+stdenv.mkDerivation rec {
+    pname = "libecpint";
+    version = "1.0.7";
+
+    nativeBuildInputs = [
+      cmake
+      gtest
+    ];
+
+    buildInputs = [
+      pugixml
+    ];
+
+    propagatedBuildInputs = [
+      python3
+    ];
+
+    src = fetchFromGitHub {
+      owner = "robashaw";
+      repo = pname;
+      rev = "v${version}";
+      hash = "sha256-2p2Ndl2TPeTo2310Jsk+TRSou+iYfJR2MdlVddzDPNE=";
+    };
+
+    cmakeFlags = [
+      "-DLIBECPINT_MAX_L=7"
+      "-DBUILD_SHARED_LIBS=ON"
+    ];
+
+    preCheck = ''
+      export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(pwd)/src:$(pwd)/external/Faddeeva
+    '';
+    doCheck = true;
+
+    meta = with lib; {
+      description = "C++ library for the efficient evaluation of integrals over effective core potentials";
+      homepage = "https://github.com/robashaw/libecpint";
+      license = licenses.mit;
+      platforms = platforms.unix;
+    };
+  }


### PR DESCRIPTION
[Upstream Release](https://github.com/psi4/psi4/releases/tag/v1.6)

This is an update to the latest upstream release. it also adds support for the CPPE library with polarisable embedding and LibECPint for fast ECP intergrals.

Of course Psi4 has again changed how to build libint, so we are again rebuilding libint ...