### PR TITLE
XTB 6.4.1 -> 6.5.1

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -172,6 +172,8 @@ let
 
         macroqc = callPackage ./pkgs/apps/macroqc { };
 
+        mctc-lib = callPackage ./pkgs/lib/mctc-lib { };
+
         mctdh = callPackage ./pkgs/apps/mctdh { };
 
         meep = super.python3.pkgs.toPythonApplication self.python3.pkgs.meep;

--- a/overlay.nix
+++ b/overlay.nix
@@ -161,6 +161,8 @@ let
 
         janpa = callPackage ./pkgs/apps/janpa { };
 
+        json-fortran = callPackage ./pkgs/lib/json-fortran { };
+
         luscus = callPackage ./pkgs/apps/luscus { };
 
         nwchem = callPackage ./pkgs/apps/nwchem {

--- a/overlay.nix
+++ b/overlay.nix
@@ -280,6 +280,8 @@ let
 
         stream-benchmark = callPackage ./pkgs/apps/stream { };
 
+        test-drive = callPackage ./pkgs/lib/test-drive { };
+
         tinker = callPackage ./pkgs/apps/tinker { };
 
         travis-analyzer = callPackage ./pkgs/apps/travis-analyzer { };

--- a/pkgs/apps/pysisyphus/default.nix
+++ b/pkgs/apps/pysisyphus/default.nix
@@ -70,7 +70,7 @@ let
 in
   buildPythonPackage rec {
     pname = "pysisyphus";
-    version = "0.7.6.post2";
+    version = "0.7.6.post3";
 
     nativeBuildInputs = [ makeWrapper setuptools-scm ];
 
@@ -115,8 +115,8 @@ in
     src = fetchFromGitHub {
       owner = "eljost";
       repo = pname;
-      rev = version;
-      hash = "sha256-QAzsoVExSmG3CKyHMkCk+JbtAUvRqCa26VnvOD65Kfs=";
+      rev = "dc999130d5a0058d78ec9c19090d92656e385606";
+      hash = "sha256-KcJpDhKsB1vjPmwnNTlGsjQ6vQhFcLm8I4dfpu8r9S0=";
     };
 
     format = "pyproject";

--- a/pkgs/apps/xtb/default.nix
+++ b/pkgs/apps/xtb/default.nix
@@ -1,4 +1,5 @@
 { stdenv, lib, gfortran, fetchFromGitHub, cmake, makeWrapper, blas, lapack, writeTextFile
+, mctc-lib, test-drive
 , turbomole, enableTurbomole ? false
 , orca, enableOrca ? false
 , cefine
@@ -15,22 +16,23 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "xtb";
-  version = "6.4.1";
+  version = "6.5.1";
 
   src = fetchFromGitHub  {
     owner = "grimme-lab";
     repo = pname;
     rev = "v${version}";
-    sha256= "1cakkysjj5qm3dhia0f3frp68rysc1p6p4hm8z36j20j02vmks0i";
+    hash = "sha256-9DTaHsK1NgcNbPKsjrVNvoWTyLdaqilZ59sAjAudS2M=";
   };
 
   nativeBuildInputs = [
     gfortran
     cmake
     makeWrapper
+    test-drive
   ];
 
-  buildInputs = [ blas lapack ];
+  buildInputs = [ blas lapack mctc-lib ];
 
   hardeningDisable = [ "format" ];
 

--- a/pkgs/lib/json-fortran/default.nix
+++ b/pkgs/lib/json-fortran/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, lib, fetchFromGitHub, gfortran, cmake }:
+
+stdenv.mkDerivation rec {
+  pname = "json-fortran";
+  version = "8.3.0";
+
+  src = fetchFromGitHub {
+    owner = "jacobwilliams";
+    repo = pname;
+    rev = version;
+    hash = "sha256-96W9bzWEZ3EN4wtnDT3G3pvLdcI4SIhGJWBVPU3rNZ4=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    gfortran
+  ];
+
+  cmakeFlags = [
+    "-DUSE_GNU_INSTALL_CONVENTION=ON"
+  ];
+
+  # Due to some misconfiguration in CMake the Fortran modules end up in $out/$out.
+  # Move them back to the desired location.
+  postInstall = ''
+    mv $out/$out/include $out/.
+    rm -r $out/nix
+  '';
+
+  meta = with lib; {
+    description = "Modern Fortran JSON API";
+    homepage = "https://github.com/jacobwilliams/json-fortran";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.sheepforce ];
+  };
+}

--- a/pkgs/lib/mctc-lib/default.nix
+++ b/pkgs/lib/mctc-lib/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, lib, fetchFromGitHub, meson, ninja, gfortran, pkg-config, json-fortran, cmake }:
+
+stdenv.mkDerivation rec {
+  pname = "mctc-lib";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "grimme-lab";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-3e89g0WkZU/HTBtGaLKzhsv2RTlFk/QK0OT24BGfcKQ=";
+  };
+
+  postPatch = ''
+    substituteInPlace config/template.pc \
+      --replace 'libdir=''${prefix}/@CMAKE_INSTALL_LIBDIR@' "libdir=@CMAKE_INSTALL_LIBDIR@" \
+      --replace 'includedir=''${prefix}/@CMAKE_INSTALL_INCLUDEDIR@' "includedir=@CMAKE_INSTALL_INCLUDEDIR@"
+  '';
+
+  nativeBuildInputs = [
+    ninja
+    gfortran
+    pkg-config
+    cmake
+  ];
+
+  buildInputs = [ json-fortran ];
+
+  meta = with lib; {
+    description = "Modular computation tool chain library";
+    homepage = "https://github.com/grimme-lab/mctc-lib";
+    license = licenses.asl20;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.sheepforce ];
+  };
+}

--- a/pkgs/lib/test-drive/default.nix
+++ b/pkgs/lib/test-drive/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, lib, fetchFromGitHub, gfortran, cmake }:
+
+stdenv.mkDerivation rec {
+  pname = "test-drive";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "fortran-lang";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-ObAnHFP1Hp0knf/jtGHynVF0CCqK47eqetePx4NLmlM=";
+  };
+
+  postPatch = ''
+    substituteInPlace config/template.pc \
+      --replace 'libdir=''${prefix}/@CMAKE_INSTALL_LIBDIR@' "libdir=@CMAKE_INSTALL_LIBDIR@" \
+      --replace 'includedir=''${prefix}/@CMAKE_INSTALL_INCLUDEDIR@' "includedir=@CMAKE_INSTALL_INCLUDEDIR@"
+  '';
+
+  nativeBuildInputs = [
+    gfortran
+    cmake
+  ];
+
+  meta = with lib; {
+    description = "Procedural Fortran testing framework";
+    homepage = "https://github.com/fortran-lang/test-drive";
+    license = with licenses; [ asl20 mit ] ;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.sheepforce ];
+  };
+}


### PR DESCRIPTION
Update to the most recent XTB version with many new features and bugfixes. XTB now requires 2 new dependencies:

- mctc-lib to unify input file parsing between different Grimme group programs. mctc-lib requires
  - json-fortran to parse QCSchema input files
- test-drive to automate fortran tests in XTB