### PR TITLE
multiwfn: 3.7 -> 3.8

### DIFF
--- a/pkgs/apps/multiwfn/default.nix
+++ b/pkgs/apps/multiwfn/default.nix
@@ -1,44 +1,36 @@
-{ stdenv, lib, makeWrapper, autoPatchelfHook, unzip,
-  writeScriptBin, fetchurl, glibc, xorg, libGL, motif
-} :
+{ stdenv, lib, makeWrapper, gfortran, unzip, fetchurl, xorg, libGL, motif, mkl }:
 
 stdenv.mkDerivation rec {
   pname = "multiwfn";
-  version = "3.7";
+  version = "3.8-2022-08-24";
 
-  # Only builds with Intel tooling. ifort is not available in Nix, therefore the binary package.
   src = fetchurl {
-    url = "http://sobereva.com/multiwfn/misc/Multiwfn_${version}_bin_Linux.zip";
-    sha256 = "1xv8kicc34c5fx1mddmm9a94j5nm7nr6yrsvfm5v59a0wgk76rbs";
+    url = "http://sobereva.com/multiwfn/misc/Multiwfn_3.8_dev_src_Linux.zip";
+    hash = "sha256-2BvUiGz4WjQra2q6m8nU3OLIA6hNbOhpQJ5GKdyWj98=";
   };
 
+  patches = [
+    ./gfortran.patch
+  ];
+
   nativeBuildInputs = [
+    gfortran
     makeWrapper
-    autoPatchelfHook
     unzip
   ];
 
   buildInputs = [
     xorg.libX11
+    xorg.libXt
     libGL
     motif
+    mkl
   ];
-
-  dontConfigure = true;
-  dontBuild = true;
-
+  
   installPhase = ''
     mkdir -p $out/bin $out/share/multiwfn
-
-    # Copy binary to $out
-    chmod +x Multiwfn
-    cp Multiwfn $out/bin/.
-
-    # Copy examples and settings
-    cp -r examples settings.ini $out/share/multiwfn/.
-
-    # Symlink the settings.
-    ln -s $out/share/multiwfn/settings.ini $out/bin/.
+    chmod +x Multiwfn Multiwfn_noGUI
+    cp Multiwfn Multiwfn_noGUI $out/bin/.
   '';
 
   meta = with lib; {

--- a/pkgs/apps/multiwfn/gfortran.patch
+++ b/pkgs/apps/multiwfn/gfortran.patch
@@ -1,0 +1,42 @@
+diff --git a/Makefile b/Makefile
+index 5c0132a..65cb595 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,12 +1,12 @@
+ SIMD = -msse3
+-OPT = -O2 -qopenmp -qopenmp-link=static -threads -qopt-matmul $(SIMD) -diag-disable 8290,8291,6371,10316 -fpp -mkl -static-intel -DINTEL_MKL
+-OPT1 = -O1 -qopenmp -qopenmp-link=static -threads $(SIMD) -diag-disable 8290,8291,6371,10316 -fpp -mkl -static-intel -DINTEL_MKL
++OPT = -O2 -fopenmp -cpp -lmkl_gf_lp64 -lmkl_gnu_thread -lmkl_core -lgomp -lpthread -lm -ldl -ffree-line-length-none
++OPT1 = -O1 -fopenmp -cpp -lmkl_gf_lp64 -lmkl_gnu_thread -lmkl_core -lgomp -lpthread -lm -ldl -ffree-line-length-none
+ #Options in the next line is for debugging purpose
+ #OPTDBG = -O0 -qopenmp -diag-disable 8290,8291,6371 -threads -qopenmp-link=static -debug all -g -traceback -check all -fstack-protector -fpp -mkl -static-intel
+ 
+ LIB_GUI = ./dislin_d-11.0.a -lXm -lXt -lX11 -lGL   #At least works for CentOS 7.x
+ LIB_noGUI =
+-FC = ifort
++FC = gfortran
+ EXE = Multiwfn
+ EXE_noGUI = Multiwfn_noGUI
+ LIBRETAPATH = ./libreta_hybrid
+@@ -204,7 +204,7 @@ deloc_aromat.o : deloc_aromat.f90 $(modules)
+ 
+ 
+ noGUI/dislin_d_empty.o : noGUI/dislin_d_empty.f90
+-	$(FC) $(OPT) -c noGUI/dislin_d_empty.f90 -o noGUI/dislin_d_empty.o -diag-disable 6178,6843
++	$(FC) $(OPT) -c noGUI/dislin_d_empty.f90 -o noGUI/dislin_d_empty.o
+ 
+ 
+ # Interfaces of libreta-ESP to Multiwfn
+@@ -215,10 +215,10 @@ libreta.o: ${LIBRETAPATH}/libreta.f90 hrr_012345.o blockhrr_012345.o ean.o eanvr
+ # Pure libreta files for ESP
+ 
+ hrr_012345.o: ${LIBRETAPATH}/hrr_012345.f90
+-	$(FC) $(OPT) -diag-disable 6843 $(SIMD) -c ${LIBRETAPATH}/hrr_012345.f90
++	$(FC) $(OPT) $(SIMD) -c ${LIBRETAPATH}/hrr_012345.f90
+ 
+ blockhrr_012345.o: ${LIBRETAPATH}/blockhrr_012345.f90
+-	$(FC) -O1 -diag-disable 6843 $(SIMD) -c ${LIBRETAPATH}/blockhrr_012345.f90
++	$(FC) -O1 $(SIMD) -c ${LIBRETAPATH}/blockhrr_012345.f90
+ 
+ ean.o: ${LIBRETAPATH}/ean.f90 hrr_012345.o eanvrr_012345.o boysfunc.o ${LIBRETAPATH}/ean_data1.h ${LIBRETAPATH}/ean_data2.h
+ 	$(FC) $(OPT) -c ${LIBRETAPATH}/ean.f90


### PR DESCRIPTION
An update to Multiwfn. This version finally is able to build with GFortran and droppped all the custom IFort extensions. A patch to build with gfortran for the Makefile is necessary.

Unfortunately this is declared the development version and no stable link seems to be provided. If a new dev version is uploaded it will break the hash. However, to cite the website:

> Latest formal version: 3.7　　Release date: 2020-Aug-14
(DO NOT use this currently, it is already quite old and no longer maintained!)

What do you think @markuskowa ? Should we update the hash whenever it breaks or wait for 3.8 to become stable?