### PR TITLE
pegamoid: fix division type error in window size

### DIFF
--- a/pkgs/apps/pegamoid/Compat.patch
+++ b/pkgs/apps/pegamoid/Compat.patch
@@ -1,0 +1,13 @@
+diff --git a/pegamoid.py b/pegamoid.py
+index bc44be5..a20af5c 100755
+--- a/pegamoid.py
++++ b/pegamoid.py
+@@ -2584,7 +2584,7 @@ class LineEditWithButton(QLineEdit):
+   def resizeEvent(self, event):
+     sz = self.button.sizeHint()
+     frameWidth = self.style().pixelMetric(QStyle.PM_DefaultFrameWidth)
+-    self.button.move(self.rect().right() - frameWidth - sz.width(), (self.rect().bottom() + 1 - sz.height())/2)
++    self.button.move(self.rect().right() - frameWidth - sz.width(), (self.rect().bottom() + 1 - sz.height())//2)
+   def setButton(self, text):
+     self.button.setText(text)
+     self.button.setVisible(bool(text))

--- a/pkgs/apps/pegamoid/default.nix
+++ b/pkgs/apps/pegamoid/default.nix
@@ -17,7 +17,7 @@ buildPythonApplication rec {
   # The samples and screenshots directories confuse setuptools and they
   # refuse to build as long as these directories are present.
   prePatch = "rm -rf samples screenshots";
-  patches = [ ./pipVTK.patch ];
+  patches = [ ./pipVTK.patch ./Compat.patch ];
 
   propagatedBuildInputs = [
     numpy


### PR DESCRIPTION
Pegamoid broke, most likely with an PyQT update from nixpkgs. The problem is a wrong float/integer division. The included patch fixes this.