### PR TITLE
macroqc: init at 1.0

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -166,6 +166,8 @@ let
           lapack = final.lapack-ilp64;
         };
 
+        macroqc = callPackage ./pkgs/apps/macroqc { };
+        
         mctdh = callPackage ./pkgs/apps/mctdh { };
 
         meep = super.python3.pkgs.toPythonApplication self.python3.pkgs.meep;

--- a/pkgs/apps/macroqc/default.nix
+++ b/pkgs/apps/macroqc/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, lib, fetchurl, unzip, autoPatchelfHook, libllvm }:
+
+stdenv.mkDerivation rec {
+  pname = "MacroQC";
+  version = "1.0.6-2022-09-09";
+
+  src = fetchurl {
+    url = "https://macroqc.hacettepe.edu.tr/src/binaries/macroqc.zip";
+    hash = "sha256-5O4BMMowXM7UOShXLnS6L4rgQEZmU/osGyez/005bQk=";
+  };
+
+  unpackPhase = ''
+    ${unzip}/bin/unzip ${src}
+    cd macroqc
+  '';
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+
+  buildInputs = [ libllvm ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -r include lib share $out/.
+    cp bin/macroqc $out/bin/.
+  '';
+
+  autoPatchelfIgnoreMissingDeps = true;
+
+  meta = with lib; {
+    description = "An electronic structure theory software for large-scale applications";
+    homepage = "https://macroqc.hacettepe.edu.tr/index.html";
+    license = licenses.unfree;
+    platforms = platforms.linux;
+    mainProgram = "macroqc";
+    maintainers = [ maintainers.sheepforce ];
+  };
+}


### PR DESCRIPTION
Adds the MacroQC program with a set of correlated and fast wave function methods and support for SMF fragment calculations.

The link is probably unstable as it contains no version number. Same problem as with Multiwfn.