### PR TITLE
xtb-python: disable instable orbital signs test

### DIFF
--- a/pkgs/lib/xtb-python/default.nix
+++ b/pkgs/lib/xtb-python/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
   '';
 
   checkInputs = [ pytestCheckHook ];
-  pytestFlagsArray = [ "-k 'not qcschema'" ]; # Numerically soooo slightly off
+  pytestFlagsArray = [ "-k 'not (qcschema or gfn2xtb_orbitals)'" ]; # Numerically soooo slightly off
   pythonImportsCheck = [ "xtb.interface" "xtb.libxtb" ];
 
   meta = with lib; {


### PR DESCRIPTION
Disables test for the MO coefficients. The test is unstable and the signs of the orbitals may change depending on the LAPACK/BLAS implementation.

Closes #220 