### PR TITLE
Pegamoid and Multiwfn fixes

### DIFF
--- a/pkgs/apps/multiwfn/default.nix
+++ b/pkgs/apps/multiwfn/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://sobereva.com/multiwfn/misc/Multiwfn_3.8_dev_src_Linux.zip";
-    hash = "sha256-FrO6GgXcXQogUgzZP0OWlvU/IYMFr0v/emeVRYi146s=";
+    hash = "sha256-ON96OD61RNFPuTxs0pwF1/jlVC2l45OIdTmxsPx9cKM=";
   };
 
   patches = [

--- a/pkgs/apps/pegamoid/default.nix
+++ b/pkgs/apps/pegamoid/default.nix
@@ -1,5 +1,5 @@
-{ buildPythonApplication, fetchFromGitLab, lib
-, numpy, h5py, pyqt5, qtpy, future, vtk
+{ buildPythonApplication, python3, fetchFromGitLab, lib
+, numpy, h5py, pyqt5, qtpy, future, vtk, qt5
 } :
 
 buildPythonApplication rec {
@@ -19,6 +19,10 @@ buildPythonApplication rec {
   prePatch = "rm -rf samples screenshots";
   patches = [ ./pipVTK.patch ./Compat.patch ];
 
+  preConfigure = ''
+    export PYTHONPATH=$PYTHONPATH:${vtk}/${python3.sitePackages}
+  '';
+
   propagatedBuildInputs = [
     numpy
     h5py
@@ -27,6 +31,12 @@ buildPythonApplication rec {
     vtk
     future
   ];
+
+  nativeBuildInputs = [ qt5.wrapQtAppsHook ];
+
+  preFixup = ''
+    wrapQtApp "$out/bin/pegamoid.py"
+  '';
 
   meta = with lib; {
     description = "Python GUI for OpenMolcas";


### PR DESCRIPTION
Fixes two apps.

Pegamoid didn't start anymore complaining about incompatible Qt versions being mixed. It used the Qt version of my KDE and broke when this started diverging from the version PyQt was using. Frankly, it was probably always broken and sheer luck that it was working. `wrapQtApps` solves this problem.

Multiwfn changed the hash again.