### PR TITLE
mcdth: mark as broken (requires python-2.7)

### DIFF
--- a/pkgs/apps/mctdh/default.nix
+++ b/pkgs/apps/mctdh/default.nix
@@ -93,6 +93,7 @@ in stdenv.mkDerivation {
     description = "Multi configuration time dependent hartree dynamics package";
     homepage = "https://www.pci.uni-heidelberg.de/cms/mctdh.html";
     license = licenses.unfree;
+    broken = true; # Relies on python-2.7
     maintainers = [ maintainers.markuskowa ];
     platforms = [ "x86_64-linux" ];
   };


### PR DESCRIPTION
see https://github.com/markuskowa/NixOS-QChem/issues/241