### PR TITLE
nixpkgs-opt: use lib.fix to generate clean overrides

### DIFF
--- a/nixpkgs-opt.nix
+++ b/nixpkgs-opt.nix
@@ -5,137 +5,115 @@ cfg: final: prev: self: optStdenv:
 # and optimizations of upstream packages
 #
 
-with final;
 let
   hp = optStdenv.hostPlatform;
+  inherit (final) lib;
 
-  # like callPackage but with override instead
-  recallPackage = pkg: inputs:
-    pkg.override ((builtins.intersectAttrs pkg.override.__functionArgs set) // inputs);
+  optSet = lib.fix (self:
+    let
+      recallPackage = x: inputs: x.override ((builtins.intersectAttrs x.override.__functionArgs self) // inputs);
+    in {
+      stdenv = optStdenv;
+      inherit (self.stdenv) hostPlatform;
 
-  set = {
-    stdenv = optStdenv;
-    avogadro2 = recallPackage avogadro2 {};
-    arpack = recallPackage arpack {};
-    arpack-mpi = recallPackage arpack {
-      inherit (self) mpi;
-      useMpi = true;
-    };
-    boost-mpi = recallPackage boost {
-      useMpi = true;
-      inherit (self) mpi;
-    };
+      avogadro2 = recallPackage final.avogadro2 {};
+      arpack = recallPackage final.arpack {};
+      arpack-mpi = recallPackage final.arpack {
+        useMpi = true;
+      };
+      boost-mpi = recallPackage final.boost {
+        useMpi = true;
+      };
 
-    cp2k = recallPackage cp2k {
-      libxc = pkgs.libxc_7;
-      inherit (final)
-        mpi
-        fftw
-        dbcsr
-        dftd4
-        simple-dftd3
-        sirius
-        multicharge
-        libxsmm
-        spglib
-        scalapack
-      ;
-    };
+      cp2k = recallPackage final.cp2k {
+        libxc = self.libxc_7;
+      };
 
-    dbscr = recallPackage dbcsr {};
-    fftw = recallPackage fftw {};
-    fftwMpi = recallPackage fftwMpi {
-      inherit (final) mpi;
-    };
-    dkh = recallPackage dkh {};
-    dftd4 = recallPackage dftd4 {};
-    # Currently broken upstream. Put back after next upgrade
-    # elpa = recallPackage elpa {};
-    ergoscf = recallPackage ergoscf {};
-    harminv = recallPackage harminv {};
-    inherit (final) hdf5;
-    hpl = recallPackage hpl {};
-    hpcg = recallPackage hpcg {};
-    i-pi = recallPackage i-pi {};
-    gsl = recallPackage gsl {};
-    gpaw = python3.pkgs.toPythonApplication (recallPackage python3.pkgs.gpaw {});
-    libint = recallPackage libint {};
-    libmbd = recallPackage libmbd {};
-    libvori = recallPackage libvori {};
-    libvdwxc = recallPackage libvdwxc {
-      inherit (final) mpi fftwMpi;
-    };
-    libxc = recallPackage libxc {};
-    libxc_7 = recallPackage libxc_7 {};
-    mctc-lib = recallPackage mctc-lib {};
-    mpb = recallPackage mpb {};
-    meep = python3.pkgs.toPythonApplication (recallPackage python3.pkgs.meep {});
-    mkl = recallPackage mkl {};
-    molden = recallPackage molden {};
-    mopac = recallPackage mopac {};
-    mpi = recallPackage mpi {};
-    multicharge = recallPackage multicharge {};
-    nwchem = recallPackage nwchem {
-      inherit (self) mpi;
-      blas = final.blas-ilp64;
-      lapack = final.lapack-ilp64;
-    };
-    octopus = recallPackage octopus {};
-    openmm = recallPackage openmm {
-      enableCuda = cfg.useCuda;
-      stdenv = final.clangStdenv;
-    };
-    quantum-espresso = recallPackage quantum-espresso {
-      hdf5 = final.hdf5-fortran;
-      inherit (final) wannier90;
-    };
-    pcmsolver = recallPackage pcmsolver {};
-    scalapack = recallPackage scalapack {};
-    siesta = recallPackage siesta {};
-    siesta-mpi = recallPackage siesta-mpi {
-      inherit (final) scalapack mpi;
-    };
-    simple-dftd3 = recallPackage simple-dftd3 {};
-    sirius = recallPackage sirius {
-      inherit (final) scalapack mpi;
-    };
-    spglib = recallPackage spglib {};
+      dbcsr = recallPackage final.dbcsr {};
+      fftw = recallPackage final.fftw {};
+      fftwMpi = recallPackage final.fftwMpi {};
+      fftwSinglePrec = recallPackage final.fftwSinglePrec {};
+      dkh = recallPackage final.dkh {};
+      dftd4 = recallPackage final.dftd4 {};
+      # Currently broken upstream. Put back after next upgrade
+      elpa = recallPackage final.elpa {};
+      ergoscf = recallPackage final.ergoscf {};
+      harminv = recallPackage final.harminv {};
+      hdf5 = recallPackage final.hdf5 {};
+      hpl = recallPackage final.hpl {};
+      hpcg = recallPackage final.hpcg {};
+      i-pi = recallPackage final.i-pi {};
+      gsl = recallPackage final.gsl {};
+      gpaw = final.python3.pkgs.toPythonApplication (recallPackage final.python3.pkgs.gpaw {});
+      libint = recallPackage final.libint {};
+      libmbd = recallPackage final.libmbd {};
+      libvori = recallPackage final.libvori {};
+      libvdwxc = recallPackage final.libvdwxc {};
+      libxc = recallPackage final.libxc {};
+      libxc_7 = recallPackage final.libxc_7 {};
+      mctc-lib = recallPackage final.mctc-lib {};
+      mpb = recallPackage final.mpb {};
+      meep = final.python3.pkgs.toPythonApplication (recallPackage final.python3.pkgs.meep {});
+      mkl = recallPackage final.mkl {};
+      molbar = recallPackage final.molbar {};
+      molden = recallPackage final.molden {};
+      mopac = recallPackage final.mopac {};
+      mpi = recallPackage final.mpi {};
+      multicharge = recallPackage final.multicharge {};
+      nwchem = recallPackage final.nwchem {
+        blas = final.blas-ilp64;
+        lapack = final.lapack-ilp64;
+      };
+      octopus = recallPackage final.octopus {};
+      openmm = recallPackage final.openmm {
+        enableCuda = cfg.useCuda;
+        stdenv = final.clangStdenv;
+      };
+      quantum-espresso = recallPackage final.quantum-espresso {
+        hdf5 = final.hdf5-fortran;
+      };
+      pcmsolver = recallPackage final.pcmsolver {};
+      scalapack = recallPackage final.scalapack {};
+      siesta = recallPackage final.siesta {};
+      siesta-mpi = recallPackage final.siesta-mpi {};
+      simple-dftd3 = recallPackage final.simple-dftd3 {};
+      sirius = recallPackage final.sirius {};
+      spglib = recallPackage final.spglib {};
+      spla = recallPackage final.spla {};
+      spfft = recallPackage final.spfft {};
+      tblite = recallPackage final.tblite {};
 
-    # tblite is broken with meson
-    # tblite = recallPackage tblite {};
-    fftwSinglePrec = self.fftw.override { precision = "single"; };
+      # gromacs = recallPackage final.gromacs {};
+      # gromacsMpi = recallPackage final.gromacsMpi {};
+      gromacs = recallPackage final.gromacs {
+        cpuAcceleration = if hp.avx2Support then "AVX2_256" else null;
+        fftw = self.fftwSinglePrec;
+      };
 
-    gromacs = recallPackage gromacs {
-      cpuAcceleration = if hp.avx2Support then "AVX2_256" else null;
-      fftw = self.fftwSinglePrec;
-    };
+      gromacsMpi = recallPackage final.gromacsMpi {
+        cpuAcceleration = if hp.avx2Support then "AVX2_256" else null;
+        fftw = self.fftwSinglePrec;
+      };
 
-    gromacsMpi = recallPackage gromacsMpi {
-      cpuAcceleration = if hp.avx2Support then "AVX2_256" else null;
-      fftw = self.fftwSinglePrec;
-    };
+      gromacsDouble = recallPackage final.gromacsDouble {
+        cpuAcceleration = if hp.avx2Support then "AVX2_256" else null;
+        enableCuda = false; # CUDA + double prec. not supported
+      };
 
-    gromacsDouble = recallPackage gromacsDouble {
-      cpuAcceleration = if hp.avx2Support then "AVX2_256" else null;
-      enableCuda = false; # CUDA + double prec. not supported
-    };
+      gromacsDoubleMpi = recallPackage final.gromacsDoubleMpi {
+        cpuAcceleration = if hp.avx2Support then "AVX2_256" else null;
+        enableCuda = false; # CUDA + double prec. not supported
+      };
 
-    gromacsDoubleMpi = recallPackage gromacsDoubleMpi {
-      cpuAcceleration = if hp.avx2Support then "AVX2_256" else null;
-      enableCuda = false; # CUDA + double prec. not supported
-    };
+      libxsmm = (recallPackage final.libxsmm {}).overrideAttrs ( x: {
+        makeFlags = x.makeFlags or [] ++ [ "OPT=3" ]
+          ++ lib.optional hp.avx2Support ["AVX=2" ];
+      });
 
-    libxsmm = (recallPackage libxsmm {}).overrideAttrs ( x: {
-      makeFlags = x.makeFlags or [] ++ [ "OPT=3" ]
-        ++ lib.optional hp.avx2Support ["AVX=2" ];
+      ucx = recallPackage final.ucx {};
+      ucc = recallPackage final.ucc {};
+      wannier90 = recallPackage final.wannier90 {};
+      wxmacmolplt = recallPackage final.wxmacmolplt {};
     });
 
-    ucx = recallPackage ucx {};
-    ucc = recallPackage ucc {};
-    wannier90 = recallPackage wannier90 {};
-    wxmacmolplt = recallPackage wxmacmolplt {};
-
-    hostPlatform = hp;
-  };
-
-in set
+in optSet


### PR DESCRIPTION
This solution is cleaner and more reliable than just using a static set.
It yields a consistent behavior: every package mentioned in this set gets rebuilt with all other optimized packages mentioned here.
That did not work reliably in the previous version.