### PR TITLE
gdma: remove git subprocess logic to obtain commit and hardcode it

### DIFF
--- a/pkgs/by-name/gdma/gitversion.patch
+++ b/pkgs/by-name/gdma/gitversion.patch
@@ -1,0 +1,15 @@
+diff --git a/src/version.py b/src/version.py
+index a57c046..8774257 100755
+--- a/src/version.py
++++ b/src/version.py
+@@ -33,9 +33,7 @@ with open(args.vfile) as IN:
+   patchlevel = re.sub("PATCHLEVEL +:= +", "", line)
+ 
+ now = datetime.today().strftime('%d %B %Y at %H:%M:%S')
+-log = subprocess.check_output("git log -n 1 --oneline", shell=True,
+-                              universal_newlines=True)
+-commit = log.split()[0]
++commit = "@COMMIT@"
+ 
+ with open(args.v90,"w") as OUT:
+   OUT.write(f"""MODULE version


### PR DESCRIPTION
Follow up to #742. For some reasons beyond my understanding, `fetchgit` with `leaveDotGit = true` gives a different hash each time. Thus, I'm removing the original reason to keep the `.git`; obtaining the commit by calling into git. Instead I'm just hardcoding the commit string now.