### PR TITLE
qdng: protobuf has been renamed protobuf3_21 -> protobuf_21

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -204,7 +204,7 @@ let
 
         qdng = callPackage ./pkgs/by-name/qdng/package.nix {
           stdenv = aggressiveStdenv;
-          protobuf = final.protobuf3_21;
+          protobuf = final.protobuf_21;
         };
 
         qmcpack = super.python3.pkgs.toPythonApplication self.python3.pkgs.qmcpack;


### PR DESCRIPTION
For the next flake.lock update.