### PR TITLE
xtb: fix qcg and docking crash with crest

### DIFF
--- a/pkgs/by-name/xtb/package.nix
+++ b/pkgs/by-name/xtb/package.nix
@@ -52,6 +52,12 @@ stdenv.mkDerivation rec {
   patches = [
     ./build.patch
     ./pkg-config.patch
+
+    # Fixes QCG crash with current xTB versions
+    (fetchpatch {
+      url = "https://patch-diff.githubusercontent.com/raw/grimme-lab/xtb/pull/1089.patch";
+      hash = "sha256-ZB/yz1EAfuxVwYFr5xjpgrDg09/3YLC45AzXkuzax84=";
+    })
   ];
 
   outputs = [ "out" "dev" ];


### PR DESCRIPTION
Fixes crashes in xTB's docking routines and QCG with CREST via a not yet released upstream patch, see github.com/grimme-lab/xtb/pull/1089/files