### PR TITLE
iboview: workaround for qt issues on wayland

### DIFF
--- a/pkgs/apps/iboview/default.nix
+++ b/pkgs/apps/iboview/default.nix
@@ -47,6 +47,11 @@ stdenv.mkDerivation rec {
     cp iboview $out/bin/.
   '';
 
+  qtWrapperArgs = [
+    # Required on wayland to force xwayland usage. Graphics issues otherwise.
+    "--set-default QT_QPA_PLATFORM xcb"
+  ];
+
   meta = with lib; {
     description = "Calculator and visualiser for Intrinsic Bond Orbitals";
     homepage = "http://www.iboview.org/index.html";


### PR DESCRIPTION
IboView does not work properly on wayland and produces graphic glitches that make it unusable. By setting `QT_QPA_PLATFORM=xcb` we can force xwayland usage, under which IboView behaves correctly.